### PR TITLE
Fix MIP sharp display

### DIFF
--- a/modules/display/mip_display.py
+++ b/modules/display/mip_display.py
@@ -22,7 +22,6 @@ except ImportError:
 
 app_logger.info(f"MIP DISPLAY: {_SENSOR_DISPLAY}")
 
-
 # https://qiita.com/hishi/items/669ce474fcd76bdce1f1
 # LPM027M128C, LPM027M128B,
 

--- a/modules/display/mip_sharp_display.py
+++ b/modules/display/mip_sharp_display.py
@@ -114,7 +114,7 @@ class MipSharpDisplay:
             self.pi.write(GPIO_SCS, 0)
             self.draw_queue.task_done()
 
-    async def update(self, im_array, direct_update):
+    def update(self, im_array, direct_update):
         if not _SENSOR_DISPLAY or self.config.G_QUIT:
             return
 
@@ -140,17 +140,16 @@ class MipSharpDisplay:
             time.sleep(0.000006)
             self.pi.write(GPIO_SCS, 0)
         else:
-            await self.draw_queue.put((self.img_buff_rgb8[diff_lines].tobytes()))
+            asyncio.create_task(
+                self.draw_queue.put((self.img_buff_rgb8[diff_lines].tobytes()))
+            )
 
-    async def quit(self):
-        if not _SENSOR_DISPLAY:
-            return
-
-        await self.draw_queue.put(None)
+    def quit(self):
+        asyncio.create_task(self.draw_queue.put(None))
         self.clear()
 
         self.pi.write(GPIO_DISP, 1)
-        await asyncio.sleep(0.01)
+        time.sleep(0.01)
 
         self.pi.spi_close(self.spi)
         self.pi.stop()

--- a/modules/helper/setting.py
+++ b/modules/helper/setting.py
@@ -162,7 +162,7 @@ class Setting:
 
         if "DISPLAY_PARAM" in self.config_parser:
             if "SPI_CLOCK" in self.config_parser["DISPLAY_PARAM"]:
-                self.config.G_DISPLAY_PARAM["SPI_CLOCK"] = float(
+                self.config.G_DISPLAY_PARAM["SPI_CLOCK"] = int(
                     self.config_parser["DISPLAY_PARAM"]["SPI_CLOCK"]
                 )
 


### PR DESCRIPTION
Looks like it got broken when porting to asyncio, I just picked the way it's done on mip_display.

In this case G_DISPLAY_PARAM["SPI_CLOCK"] needs to be an integer, it was now casted to a float.
I can't test a MIP display but maybe it's needed for this display?