### PR TITLE
improve bluetooth/wifi on/off settings

### DIFF
--- a/modules/logger_core.py
+++ b/modules/logger_core.py
@@ -897,8 +897,8 @@ class LoggerCore:
             shutil.copy(self.config.G_LOG_DB, db_file)
 
             query = (
-                'SELECT distance,position_lat,position_long FROM BIKECOMPUTER_LOG '
-                + 'WHERE position_lat is not null AND position_long is not null '
+                "SELECT distance,position_lat,position_long FROM BIKECOMPUTER_LOG "
+                + "WHERE position_lat is not null AND position_long is not null "
                 + 'and typeof(position_lat) = "real" and typeof(position_long) = "real"'
             )
             if timestamp is not None:

--- a/reqs/full.in
+++ b/reqs/full.in
@@ -1,5 +1,6 @@
 -r min.in
 
+dbus-next==0.2.3
 garminconnect==0.1.55
 polyline==2.0.0
 stravacookies==1.3

--- a/reqs/full.txt
+++ b/reqs/full.txt
@@ -13,6 +13,7 @@ certifi==2023.7.22
 charset-normalizer==3.2.0
 cloudscraper==1.2.71
 crdp @ git+https://github.com/hishizuka/crdp.git
+dbus-next==0.2.3
 frozenlist==1.4.0
 garminconnect==0.1.55
 html5lib==1.1


### PR DESCRIPTION
[Work in progress]

- do not use rkfill for bluetooth
- do not make it RASPI only
- mv detect_network + no need for global for IO address: bluetooth tethering not only on Raspi

1.I'd rather not used rfkill for wifi too (I end up having to reboot the system anyway to get it back, one way could be to do "ip link set xxx down/up", I think in both case, rfkill or this, the wifi module is powered anyway) ?
2.I realize now the IS_RASPI in some places is because you are running the code on MacOS and can't can't run linux command. So this def won't work for you.
But then, maybe we should introduce a IS_RASPI and IS_LINUX (or IS_VALID_PLATFORM) so these code paths can be tested on a computer too ?