### PR TITLE
Fix rfkill commands

### DIFF
--- a/modules/helper/api.py
+++ b/modules/helper/api.py
@@ -10,6 +10,7 @@ import aiofiles
 
 import numpy as np
 
+from modules.utils.network import detect_network
 from logger import app_logger
 
 _IMPORT_GARMINCONNECT = False
@@ -59,11 +60,8 @@ class api:
             self.course_send_status = "RESET"
             self.bt_cmd_lock = False
 
-    async def get_google_route(self, x1, y1, x2, y2):
-        if (
-            not self.config.detect_network()
-            or self.config.G_GOOGLE_DIRECTION_API["TOKEN"] == ""
-        ):
+    async def get_google_routes(self, x1, y1, x2, y2):
+        if not detect_network() or self.config.G_GOOGLE_DIRECTION_API["TOKEN"] == "":
             return None
         if np.any(np.isnan([x1, y1, x2, y2])):
             return None
@@ -101,10 +99,7 @@ class api:
         return response
 
     async def get_openweathermap_data(self, x, y):
-        if (
-            not self.config.detect_network()
-            or self.config.G_OPENWEATHERMAP_API["TOKEN"] == ""
-        ):
+        if detect_network() or self.config.G_OPENWEATHERMAP_API["TOKEN"] == "":
             return None
         if np.any(np.isnan([x, y])):
             return None
@@ -120,7 +115,7 @@ class api:
 
     async def get_ridewithgps_route(self, add=False, reset=False):
         if (
-            not self.config.detect_network()
+            detect_network()
             or self.config.G_RIDEWITHGPS_API["APIKEY"] == ""
             or self.config.G_RIDEWITHGPS_API["TOKEN"] == ""
         ):
@@ -287,7 +282,7 @@ class api:
 
     def upload_check(self, blank_check, blank_msg, file_check=True):
         # network check
-        if not self.config.detect_network():
+        if not detect_network():
             app_logger.warning("No Internet connection")
             return False
 
@@ -448,7 +443,7 @@ class api:
 
     async def get_scw_list(self, wind_config, mode=None):
         # network check
-        if not self.config.detect_network():
+        if not detect_network():
             app_logger.warning("No Internet connection")
             return None
 
@@ -482,7 +477,7 @@ class api:
             app_logger.warning("Install stravacookies")
             return
 
-        if not self.config.detect_network():
+        if not detect_network():
             return None
 
         strava_cookie = StravaCookieFetcher()
@@ -520,7 +515,7 @@ class api:
             return False
         # network check
         if (
-            not self.config.detect_network()
+            not detect_network()
             and not self.config.G_THINGSBOARD_API["AUTO_UPLOAD_VIA_BT"]
         ):
             # print("No Internet connection")
@@ -553,7 +548,7 @@ class api:
 
             while (
                 bt_pan_status
-                and not self.config.detect_network()
+                and not detect_network()
                 and count < self.config.G_THINGSBOARD_API["TIMEOUT_SEC"]
             ):
                 await asyncio.sleep(1)
@@ -568,7 +563,7 @@ class api:
                 await asyncio.sleep(5)
                 self.bt_cmd_lock = False
                 app_logger.error(
-                    f"[BT] {timestamp_str} connect error, network status: {self.config.detect_network()}"
+                    f"[BT] {timestamp_str} connect error, network status: {detect_network()}"
                 )
                 self.config.logger.sensor.values["integrated"]["send_time"] = (
                     datetime.datetime.now().strftime("%H:%M") + "CE"
@@ -637,7 +632,7 @@ class api:
         if self.config.G_THINGSBOARD_API["AUTO_UPLOAD_VIA_BT"]:
             bt_pan_status = await self.config.bluetooth_tethering(disconnect=True)
             self.bt_cmd_lock = False
-            network_status = self.config.detect_network()
+            network_status = detect_network()
             # print("[BT] {} disconnect, network status:{}".format(timestamp_str, network_status))
             if network_status:
                 self.config.logger.sensor.values["integrated"]["send_time"] = (

--- a/modules/helper/bt_pan.py
+++ b/modules/helper/bt_pan.py
@@ -26,7 +26,6 @@ except ImportError:
 
 class BTPan:
     bus = None
-    is_available = False
     devices = {}
 
     obj_bluez = "org.bluez"
@@ -45,10 +44,11 @@ class BTPanDbusNext(BTPan):
     async def check_dbus(self):
         try:
             self.bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
-            introspection = await self.bus.introspect(self.obj_bluez, self.path_bluez)
-            self.is_available = True
-        except:
-            pass
+            await self.bus.introspect(self.obj_bluez, self.path_bluez)
+            return True
+        except Exception as e:
+            app_logger.warning(f"DBus not available {e}")
+            return False
 
     async def find_bt_pan_devices(self):
         res = {}
@@ -123,10 +123,11 @@ class BTPanDbus(BTPan):
     async def check_dbus(self):
         try:
             self.bus = dbus.SystemBus()
-            proxy = self.bus.get_name_owner(self.obj_bluez)
-            self.is_available = True
-        except:
-            pass
+            self.bus.get_name_owner(self.obj_bluez)
+            return True
+        except Exception as e:
+            app_logger.warning(f"DBus not available {e}")
+            return False
 
     def get_managed_objects(self):
         manager = dbus.Interface(

--- a/modules/helper/network.py
+++ b/modules/helper/network.py
@@ -9,6 +9,7 @@ import aiofiles
 
 from logger import app_logger
 from modules.helper.api import api
+from modules.utils.network import detect_network
 
 
 class Network:
@@ -81,7 +82,7 @@ class Network:
     async def download_maptile(
         self, map_config, map_name, z, tiles, additional_download=False
     ):
-        if not self.config.detect_network() or map_config[map_name]["url"] is None:
+        if not detect_network() or map_config[map_name]["url"] is None:
             return False
 
         urls = []
@@ -242,7 +243,7 @@ class Network:
         return res
 
     async def download_demtile(self, z, x, y):
-        if not self.config.detect_network():
+        if not detect_network():
             return False
         header = {}
         try:

--- a/modules/pyqt/menu/pyqt_course_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_course_menu_widget.py
@@ -10,6 +10,7 @@ from modules._pyqt import (
     qasync,
 )
 from modules.pyqt.components import icons, topbar
+from modules.utils.network import detect_network
 from .pyqt_menu_widget import (
     MenuWidget,
     ListWidget,
@@ -44,7 +45,7 @@ class CoursesMenuWidget(MenuWidget):
         self.add_buttons(button_conf)
 
         # if not self.config.G_GOOGLE_DIRECTION_API["HAVE_API_TOKEN"]:
-        #  self.button['Google Directions API mode'].disable()
+        #  self.buttons['Google Directions API mode'].disable()
 
         if not self.config.G_IS_RASPI or not os.path.isfile(self.config.G_OBEXD_CMD):
             self.buttons["Android Google Maps"].disable()
@@ -427,7 +428,7 @@ class CourseDetailWidget(MenuWidget):
             self.enable_next_button()
             return res
         # if no internet connection, stop timer and exit
-        elif not self.config.detect_network():
+        elif not detect_network():
             return True
         return False
 

--- a/modules/sensor/sensor_i2c.py
+++ b/modules/sensor/sensor_i2c.py
@@ -4,6 +4,7 @@ import asyncio
 
 import numpy as np
 
+from modules.utils.network import detect_network
 from logger import app_logger
 from .sensor import Sensor
 
@@ -775,7 +776,7 @@ class SensorI2C(Sensor):
             _SENSOR_MAG_DECLINATION
             and not self.is_mag_declination_modified
             and self.config.logger is not None
-            and self.config.detect_network()
+            and detect_network()
         ):
             v = self.config.logger.sensor.values["GPS"]
             if not np.any(np.isnan([v["lat"], v["lon"]])):

--- a/modules/utils/cmd.py
+++ b/modules/utils/cmd.py
@@ -28,8 +28,10 @@ def exec_cmd_return_value(cmd, cmd_print=True):
         app_logger.exception(f"Failed executing {cmd}")
 
 
+def is_service_running(service):
+    return not exec_cmd(["systemctl", "is-active", "--quiet", service], cmd_print=False)
+
+
 # TODO we might want to compare pid, because it might be running as a service AND manually
 def is_running_as_service():
-    return not exec_cmd(
-        ["sudo", "systemctl", "is-active", "--quiet", "pizero_bikecomputer"]
-    )
+    return is_service_running("pizero_bikecomputer")

--- a/modules/utils/network.py
+++ b/modules/utils/network.py
@@ -1,0 +1,11 @@
+import socket
+
+
+def detect_network():
+    try:
+        socket.setdefaulttimeout(3)
+        connect_interface = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        connect_interface.connect(("8.8.8.8", 53))
+        return connect_interface.getsockname()[0]
+    except socket.error:
+        return False

--- a/scripts/comment_out.sh
+++ b/scripts/comment_out.sh
@@ -1,9 +1,4 @@
 #!/bin/sh
 
-sudo sed -i -e "s/^dtoverlay\=disable\-bt/\#dtoverlay\=disable\-bt/" /boot/config.txt
-sudo sed -i -e "s/^dtoverlay\=disable\-wifi/\#dtoverlay\=disable\-wifi/" /boot/config.txt
-
 sudo sed -i -e "s/^\#DEVICES\=\"\/dev\/ttyS0\"/DEVICES\=\"\/dev\/ttyS0\"/" /etc/default/gpsd
 sudo sed -i -e "s/^DEVICES\=\"\/dev\/ttyAMA0\"/\#DEVICES\=\"\/dev\/ttyAMA0\"/" /etc/default/gpsd
-
-

--- a/scripts/uncomment.sh
+++ b/scripts/uncomment.sh
@@ -1,8 +1,3 @@
 #!/bin/sh
-
-sudo sed -i -e "s/^\#dtoverlay\=disable\-bt/dtoverlay\=disable\-bt/" /boot/config.txt
-sudo sed -i -e "s/^\#dtoverlay\=disable\-wifi/dtoverlay\=disable\-wifi/" /boot/config.txt
-
 sudo sed -i -e "s/^DEVICES\=\"\/dev\/ttyS0\"/\#DEVICES\=\"\/dev\/ttyS0\"/" /etc/default/gpsd
 sudo sed -i -e "s/^\#DEVICES\=\"\/dev\/ttyAMA0\"/DEVICES\=\"\/dev\/ttyAMA0\"/" /etc/default/gpsd
-


### PR DESCRIPTION
1. move detect_network
2. no need for global for Ip address
3. comment wifi/bt  n 'python'
4. Fix rfkill command

These are the 'safe' changes from #37 (that do not change the logic to check for IS_RASPI and still uses rfkill for both BT and WiFi).
Btw, the rfkill commands were not working for me, they have to be ran as sudo on the Pi for and the devices are under "rfkilldevices" key and not "", not sure why?
Also I kept the comment/uncomment scripts since there some commands for GPSD but it's not clear why it's there in the first place
