### PR TITLE
add Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,13 @@
+FROM python:3.11.6-slim-bookworm
+
+RUN apt update
+RUN apt install -y gcc git libsqlite3-dev python3-pyqt5 sqlite3
+
+WORKDIR /opt
+
+COPY ./reqs/full.txt .
+RUN python -m pip install -r full.txt
+# still needed
+RUN python -m pip install PyQt5
+
+ENTRYPOINT ["python", "pizero_bikecomputer.py"]


### PR DESCRIPTION
Hey,
It's a tentative try to start using containers for development and avoid having specific MacOS/Windows behavior. 
Note that it's using python bookworm image, we can change to bullseye if needed. (Also tried with a pure debian image but the handling of python deps comes with some headaches, it's just easier that way)

I don't have a Mac handy to test so this is probably not working 'as is'. 
Found this gist:
https://gist.github.com/cschiewek/246a244ba23da8b9f0e7b11a68bf3285
(If you don't use Windows either, I wouldn't bother much making this work for it)

I'm using podman but docker should work too:
1. Build with
```
podman build . -t pizero_bikecomputer
```

2. Run with
```
podman run -v .:/opt -v /tmp/.X11-unix:/tmp/.X11-unix -e "DISPLAY=:0" pizero_bikecomputer
```