### PR TITLE
Fix GPS changes

### DIFF
--- a/doc/software_installation.md
+++ b/doc/software_installation.md
@@ -86,7 +86,7 @@ $ cd pizero_bikecomputer
 Assume Serial interface is on and login shell is off in raspi-config and GPS device is connected as /dev/ttyS0. If GPS device is /dev/ttyAMA0, modify gpsd config file(/etc/default/gpsd).
 
 ```
-$ sudo apt-get install gpsd gpsd-clients python3-dateutil
+$ sudo apt-get install gpsd gpsd-clients
 $ sudo pip3 install gps3 timezonefinder 
 $ sudo cp install/etc/default/gpsd /etc/default/gpsd
 $ sudo systemctl enable gpsd
@@ -99,7 +99,6 @@ Check with `cgps` or `gpsmon` command.
 Assume I2C interface is on in raspi-config.
 
 ```
-$ sudo apt-get install python3-dateutil
 $ sudo pip3 install timezonefinder pa1010d
 ```
 

--- a/modules/button_config.py
+++ b/modules/button_config.py
@@ -146,7 +146,7 @@ class Button_Config:
     G_BUTTON_MODE_IS_CHANGE = False
     G_BUTTON_MODE_PAGES = {
         "MAIN": ["MAIN", "MAIN_1"],
-        #'MAP': ['MAP','MAP_1','MAP_2'],
+        # 'MAP': ['MAP','MAP_1','MAP_2'],
         "MAP": ["MAP", "MAP_1"],
         "COURSE_PROFILE": ["COURSE_PROFILE", "COURSE_PROFILE_1"],
     }

--- a/modules/config.py
+++ b/modules/config.py
@@ -430,8 +430,6 @@ class Config:
     G_GPS_NULLVALUE = "n/a"
     # GPS speed cutoff (the distance in 1 seconds at 0.36km/h is 10cm)
     G_GPS_SPEED_CUTOFF = G_AUTOSTOP_CUTOFF  # m/s
-    # timezone (not use, get from GPS position)
-    G_TIMEZONE = None
     # GPSd error handling
     G_GPSD_PARAM = {
         "EPX_EPY_CUTOFF": 100.0,
@@ -1072,7 +1070,7 @@ class Config:
                         "sed",
                         "-i",
                         "-e",
-                        's/^DEVICES\="\/dev\/ttyS0"/\#DEVICES\="\/dev\/ttyS0"/',
+                        r's/^DEVICES\="\/dev\/ttyS0"/\#DEVICES\="\/dev\/ttyS0"/',
                         "/etc/default/gpsd",
                     ],
                     False,
@@ -1083,7 +1081,7 @@ class Config:
                         "sed",
                         "-i",
                         "-e",
-                        's/^\#DEVICES\="\/dev\/ttyAMA0"/DEVICES\="\/dev\/ttyAMA0"/',
+                        r's/^\#DEVICES\="\/dev\/ttyAMA0"/DEVICES\="\/dev\/ttyAMA0"/',
                         "/etc/default/gpsd",
                     ],
                     False,

--- a/modules/logger/logger_fit.py
+++ b/modules/logger/logger_fit.py
@@ -556,7 +556,8 @@ class LoggerFit(Logger):
         if message_num == 18:
             lap_fields.append(5)
             lap_data.append(2)
-        app_logger.debug(lap_fields, lap_data)
+        app_logger.debug(lap_fields)
+        app_logger.debug(lap_data)
         l_num = self.get_local_message_num(message_num, lap_fields)
         if l_num == -1:
             # write header if needed

--- a/modules/pyqt/menu/pyqt_system_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_system_menu_widget.py
@@ -57,8 +57,8 @@ class NetworkMenuWidget(MenuWidget):
             ("Bluetooth", "toggle", wifi_bt_button_func_bt),
             ("BT Tethering", "submenu", self.bt_tething),
             ("IP Address", "dialog", self.show_ip_address),
-            ("Gadgetbridge", "toggle", lambda: self.onoff_ble_uart_service(True)),
-            ("Get Location", "toggle", lambda: self.onoff_gadgetbridge_gps(True)),
+            ("Gadgetbridge", "toggle", self.onoff_ble_uart_service),
+            ("Get Location", "toggle", self.onoff_gadgetbridge_gps),
         )
         self.add_buttons(button_conf)
 
@@ -77,8 +77,6 @@ class NetworkMenuWidget(MenuWidget):
         if self.config.G_IS_RASPI:
             self.onoff_wifi_bt(change=False, key="Wifi")
             self.onoff_wifi_bt(change=False, key="Bluetooth")
-        self.onoff_ble_uart_service(change=False)
-        self.onoff_gadgetbridge_gps(change=False)
 
     def onoff_wifi_bt(self, change=True, key=None):
         if change:
@@ -96,20 +94,18 @@ class NetworkMenuWidget(MenuWidget):
         self.config.gui.show_dialog_ok_only(None, address)
 
     @qasync.asyncSlot()
-    async def onoff_ble_uart_service(self, change=True):
-        if change:
-            await self.config.ble_uart.on_off_uart_service()
-            self.buttons["Gadgetbridge"].change_toggle(self.config.ble_uart.status)
-            self.buttons["Get Location"].onoff_button(self.config.ble_uart.status)
+    async def onoff_ble_uart_service(self):
+        status = await self.config.ble_uart.on_off_uart_service()
+        self.buttons["Gadgetbridge"].change_toggle(status)
+        self.buttons["Get Location"].onoff_button(status)
 
-    def onoff_gadgetbridge_gps(self, change=True):
-        if change:
-            self.config.ble_uart.on_off_gadgetbridge_gps()
-            self.buttons["Get Location"].change_toggle(self.config.ble_uart.gps_status)
+    def onoff_gadgetbridge_gps(self):
+        status = self.config.ble_uart.on_off_gadgetbridge_gps()
+        self.buttons["Get Location"].change_toggle(status)
 
 
 class DebugMenuWidget(MenuWidget):
-    is_log_lebel_debug = False
+    is_log_level_debug = False
 
     def setup_menu(self):
         button_conf = (
@@ -160,11 +156,11 @@ class DebugMenuWidget(MenuWidget):
         if change:
             if app_logger.level == logging.DEBUG:
                 app_logger.setLevel(level=logging.INFO)
-                self.is_log_lebel_debug = False
+                self.is_log_level_debug = False
             else:
                 app_logger.setLevel(level=logging.DEBUG)
-                self.is_log_lebel_debug = True
-        self.buttons["Debug Level Log"].change_toggle(self.is_log_lebel_debug)
+                self.is_log_level_debug = True
+        self.buttons["Debug Level Log"].change_toggle(self.is_log_level_debug)
 
 
 class BluetoothTetheringListWidget(ListWidget):

--- a/modules/sensor/gps/adafruit_uart.py
+++ b/modules/sensor/gps/adafruit_uart.py
@@ -1,5 +1,4 @@
 import asyncio
-import time
 
 from logger import app_logger
 from .base import AbstractSensorGPS

--- a/modules/utils/time.py
+++ b/modules/utils/time.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+
+from timezonefinder import TimezoneFinder
+
+from modules.utils.cmd import exec_cmd, exec_cmd_return_value
+from logger import app_logger
+
+
+def set_time(time_info):
+    app_logger.info(f"try to modify time to {time_info}")
+
+    last_known_date = exec_cmd_return_value(
+        [
+            "git",
+            "log",
+            "-1",
+            "--format=%cI",
+            "--date=iso-strict",
+        ],
+        cmd_print=False,
+    )
+
+    if datetime.fromisoformat(time_info) < datetime.fromisoformat(last_known_date):
+        return False
+
+    exec_cmd(
+        ["sudo", "date", "-u", "--set", time_info],
+        cmd_print=False,
+    )
+    return True
+
+
+def set_timezone(lat, lon):
+    app_logger.info("try to modify timezone by gps...")
+
+    tz_finder = TimezoneFinder()
+    try:
+        tz_str = tz_finder.timezone_at(lng=lon, lat=lat)
+
+        if tz_str is None:
+            # certain_timezone_at is deprecated since timezonefinder 6.2.0
+            tz_str = tz_finder.certain_timezone_at(lng=lon, lat=lat)
+
+        if tz_str is not None:
+            ret_code = exec_cmd(
+                ["sudo", "timedatectl", "set-timezone", tz_str], cmd_print=False
+            )
+            if ret_code:  # 0 = success
+                app_logger.warning(f"Timezone {tz_str} be could not set: {ret_code}")
+        return True
+    except TypeError as e:
+        app_logger.exception(f"Incorrect lat, lon passed: {e}")
+        return False
+    except Exception as e:
+        app_logger.warning(f"Could not set timezone: {e}")
+        return False

--- a/reqs/min.in
+++ b/reqs/min.in
@@ -4,7 +4,6 @@ git+https://github.com/hishizuka/crdp.git
 numpy==1.25.2
 oyaml==1.0
 pillow===10.0.0
-python-dateutil==2.8.2
 pyqtgraph==0.13.3
 qasync==0.24.0
 timezonefinder==6.2.0

--- a/reqs/min.txt
+++ b/reqs/min.txt
@@ -18,7 +18,6 @@ numpy==1.25.2
 oyaml==1.0
 pillow===10.0.0
 pyqtgraph==0.13.3
-python-dateutil==2.8.2
 pyyaml==6.0.1
 qasync==0.24.0
 six==1.16.0


### PR DESCRIPTION
Follow up of https://github.com/hishizuka/pizero_bikecomputer/pull/50
Remove todo and run flake8, some code simplification
it fixes logger when debug mode is set.

I've changed slightly the logic on GB. When we are getting setTime, we try to set time of the system but it's independent of the GPS code anyway. I've removed the unused G_TIMEZONE attr.

To follow up on the np.nan/None thing. All in all it gets translated to null in the database anyway but it probably changes something in the following code but I don't really get the logic behind this, what are we setting in record_stats in the end?
```
      # update lap stats if value is not Null
        for k, v in value.items():
            # skip when null value(np.nan)
            if v in [self.config.G_ANT_NULLVALUE]:
                continue
```

~~For the thing with kernel date. I do understand that you are trying to get a minimum viable date to make sure the date returned by the GPS is not behind (so somewhat validate it) ?
What about using "git log -1 --format=%cd" insted of uname to do the same ?~~
Had missed your answer. All clear
