### PR TITLE
Display inherits from base display

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -741,9 +741,9 @@ class Config:
     def init_loop(self, call_from_gui=False):
         if self.G_GUI_MODE == "PyQt":
             if call_from_gui:
-                # asyncio.set_event_loop(self.loop)
                 # workaround for latest qasync and older version(~0.24.0)
                 asyncio.events._set_running_loop(self.loop)
+                asyncio.set_event_loop(self.loop)
                 self.start_coroutine()
         else:
             self.loop = asyncio.get_event_loop()

--- a/modules/config.py
+++ b/modules/config.py
@@ -442,25 +442,7 @@ class Config:
     G_FULLSCREEN = False
 
     # display type (overwritten with setting.conf)
-    G_DISPLAY = "None"  # PiTFT, MIP, Papirus, MIP_Sharp
-
-    # screen size (need to add when adding new device)
-    G_AVAILABLE_DISPLAY = {
-        "None": {"size": (400, 240), "touch": True, "color": True},
-        "PiTFT": {"size": (320, 240), "touch": True, "color": True},
-        "MIP": {
-            "size": (400, 240),
-            "touch": False,
-            "color": True,
-        },  # LPM027M128C, LPM027M128B
-        "MIP_640": {"size": (640, 480), "touch": False, "color": True},  # LPM044M141A
-        "MIP_Sharp": {"size": (400, 240), "touch": False, "color": False},
-        "MIP_Sharp_320": {"size": (320, 240), "touch": False, "color": False},
-        "Papirus": {"size": (264, 176), "touch": False, "color": False},
-        "DFRobot_RPi_Display": {"size": (250, 122), "touch": False, "color": False},
-    }
-    G_WIDTH = 400
-    G_HEIGHT = 240
+    G_DISPLAY = "None"  # PiTFT, MIP, MIP_640, Papirus, MIP_Sharp, MIP_Sharp_320, DFRobot_RPi_Display
 
     G_DISPLAY_PARAM = {
         "SPI_CLOCK": 2000000,
@@ -759,7 +741,7 @@ class Config:
     def init_loop(self, call_from_gui=False):
         if self.G_GUI_MODE == "PyQt":
             if call_from_gui:
-                #asyncio.set_event_loop(self.loop)
+                # asyncio.set_event_loop(self.loop)
                 # workaround for latest qasync and older version(~0.24.0)
                 asyncio.events._set_running_loop(self.loop)
                 self.start_coroutine()

--- a/modules/display/dfrobot_rpi_display.py
+++ b/modules/display/dfrobot_rpi_display.py
@@ -27,6 +27,7 @@ class DFRobotRPiDisplay(Display):
 
     has_color = False
     has_touch = False
+    send = True
 
     size = (250, 122)
 

--- a/modules/display/dfrobot_rpi_display.py
+++ b/modules/display/dfrobot_rpi_display.py
@@ -1,4 +1,5 @@
 from logger import app_logger
+from .display_core import Display
 
 _SENSOR_DISPLAY = False
 
@@ -21,29 +22,32 @@ RASPBERRY_PIN_BUSY = 4
 # e-ink Display Module for Raspberry Pi 4B/3B+/Zero W version 1.0
 
 
-class DFRobotRPiDisplay:
-    config = None
+class DFRobotRPiDisplay(Display):
     epaper = None
 
-    def __init__(self, config):
-        self.config = config
+    has_color = False
+    has_touch = False
 
-        if _SENSOR_DISPLAY:
-            self.epaper = DFRobot_Epaper_SPI(
-                RASPBERRY_SPI_BUS,
-                RASPBERRY_SPI_DEV,
-                RASPBERRY_PIN_CS,
-                RASPBERRY_PIN_CD,
-                RASPBERRY_PIN_BUSY,
-            )
-            self.epaper.begin()
-            self.clear()
+    size = (250, 122)
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        self.epaper = DFRobot_Epaper_SPI(
+            RASPBERRY_SPI_BUS,
+            RASPBERRY_SPI_DEV,
+            RASPBERRY_PIN_CS,
+            RASPBERRY_PIN_CD,
+            RASPBERRY_PIN_BUSY,
+        )
+        self.epaper.begin()
+        self.clear()
 
     def clear(self):
         self.epaper.clear(self.epaper.WHITE)
         self.epaper.flush(self.epaper.FULL)
 
-    def update(self, im_array):
+    def update(self, im_array, direct_update=False):
         self.epaper.bitmap(
             0,
             0,  # start X and Y
@@ -56,5 +60,4 @@ class DFRobotRPiDisplay:
         self.epaper.flush(self.epaper.PART)
 
     def quit(self):
-        if _SENSOR_DISPLAY:
-            self.clear()
+        self.clear()

--- a/modules/display/display_core.py
+++ b/modules/display/display_core.py
@@ -21,7 +21,7 @@ SUPPORTED_DISPLAYS = {
 class Display:
     has_color = True
     has_touch = True
-    send = True
+    send = False
 
     def __init__(self, config):
         self.config = config

--- a/modules/display/display_core.py
+++ b/modules/display/display_core.py
@@ -1,135 +1,111 @@
 import os
 
 from logger import app_logger
-from ..sensor.sensor import Sensor
 
-DISPLAY = None
+DEFAULT_RESOLUTION = (400, 240)
+
+SUPPORTED_DISPLAYS = {
+    # display name, resolution if different from its class default
+    "None": None,  # DEFAULT_RESOLUTION
+    "PiTFT": None,
+    "MIP": None,  # LPM027M128C, LPM027M128B
+    "MIP_640": (640, 480),  # LPM044M141A
+    "MIP_Sharp": None,
+    "MIP_Sharp_320": (320, 240),
+    "Papirus": None,
+    "DFRobot_RPi_Display": None,
+}
 
 
-class Display(Sensor):
-    sensor = {}
-    elements = ()
-    display = None
-    send_display = False
+# default display (X window)
+class Display:
+    has_color = True
+    has_touch = True
+    send = True
 
-    def sensor_init(self):
-        self.detect_display()
-        self.set_resolution()
+    def __init__(self, config):
+        self.config = config
 
-        self.reset()
-
-        if not self.config.G_IS_RASPI:
-            self.config.G_DISPLAY = "None"
-            return
-
-        if self.config.G_DISPLAY == "PiTFT":
-            from .pitft_28_r import PiTFT28r
-
-            self.display = PiTFT28r(self.config)
-        elif self.config.G_DISPLAY in ("MIP", "MIP_640"):
-            from .mip_display import MipDisplay
-
-            self.display = MipDisplay(self.config)
-            self.send_display = True
-        elif self.config.G_DISPLAY in ("MIP_Sharp", "MIP_Sharp_320"):
-            from .mip_sharp_display import MipSharpDisplay
-
-            self.display = MipSharpDisplay(self.config)
-            self.send_display = True
-        elif self.config.G_DISPLAY == "Papirus":
-            from .papirus_display import PapirusDisplay
-
-            self.display = PapirusDisplay(self.config)
-            self.send_display = True
-        elif self.config.G_DISPLAY == "DFRobot_RPi_Display":
-            from .dfrobot_rpi_display import DFRobotRPiDisplay
-
-            self.display = DFRobotRPiDisplay(self.config)
-            self.send_display = True
-
-    def detect_display(self):
-        hatdir = "/proc/device-tree/hat"
-        product_file = hatdir + "/product"
-        vendor_file = hatdir + "/vendor"
-
-        if (os.path.exists(product_file)) and (os.path.exists(vendor_file)):
-            with open(hatdir + "/product") as f:
-                p = f.read()
-            with open(hatdir + "/vendor") as f:
-                v = f.read()
-            app_logger.info(f"{product_file}: {p}")
-            app_logger.info(f"{vendor_file}: {v}")
-
-            # set display
-            if p.find("Adafruit PiTFT HAT - 2.4 inch Resistive Touch") == 0:
-                self.config.G_DISPLAY = "PiTFT"
-            elif (p.find("PaPiRus ePaper HAT") == 0) and (v.find("Pi Supply") == 0):
-                self.config.G_DISPLAY = "Papirus"
-
-    def set_resolution(self):
-        for key in self.config.G_AVAILABLE_DISPLAY.keys():
-            if self.config.G_DISPLAY == key:
-                self.config.G_WIDTH = self.config.G_AVAILABLE_DISPLAY[key]["size"][0]
-                self.config.G_HEIGHT = self.config.G_AVAILABLE_DISPLAY[key]["size"][1]
-                break
-
-    def has_touch(self):
-        return self.config.G_AVAILABLE_DISPLAY[self.config.G_DISPLAY]["touch"]
-
-    def has_color(self):
-        return self.config.G_AVAILABLE_DISPLAY[self.config.G_DISPLAY]["color"]
+    @property
+    def resolution(self):
+        return getattr(self, "size", DEFAULT_RESOLUTION)
 
     def start_coroutine(self):
-        if self.config.G_DISPLAY in ("MIP", "MIP_640", "MIP_Sharp", "MIP_Sharp_320"):
-            self.display.start_coroutine()
+        pass
 
     def quit(self):
-        if not self.config.G_IS_RASPI:
-            return
-        if self.config.G_DISPLAY == "PiTFT":
-            pass
-        elif (
-            self.config.G_DISPLAY in ("MIP", "MIP_640", "MIP_Sharp", "MIP_Sharp_320")
-            and self.send_display
-        ):
-            self.display.quit()
-        elif self.config.G_DISPLAY in ("Papirus", "DFRobot_RPi_Display"):
-            self.display.quit()
+        pass
 
     def update(self, buf, direct_update):
-        if not self.config.G_IS_RASPI or not self.send_display:
-            return
-
-        if direct_update and self.config.G_DISPLAY in (
-            "MIP",
-            "MIP_Sharp",
-            "MIP_Sharp_320",
-        ):
-            self.display.update(buf, direct_update)
-        elif self.config.G_DISPLAY in ("MIP", "MIP_640", "MIP_Sharp", "MIP_Sharp_320"):
-            self.display.update(buf, direct_update=False)
-        elif self.config.G_DISPLAY in ("Papirus", "DFRobot_RPi_Display"):
-            self.display.update(buf)
+        pass
 
     def screen_flash_long(self):
-        if (
-            self.config.G_DISPLAY in ("MIP", "MIP_640", "MIP_Sharp", "MIP_Sharp_320")
-            and self.send_display
-        ):
-            self.display.inversion(0.8)
-            # self.display.blink(1.0)
+        pass
 
     def screen_flash_short(self):
-        if (
-            self.config.G_DISPLAY in ("MIP", "MIP_640", "MIP_Sharp", "MIP_Sharp_320")
-            and self.send_display
-        ):
-            self.display.inversion(0.3)
+        pass
 
-    def brightness_control(self):
-        if not self.config.G_IS_RASPI:
-            return
-        if self.config.G_DISPLAY == "PiTFT":
-            self.display.change_brightness()
-        elif self.config.G_DISPLAY in ("MIP", "MIP_640") and self.send_display:
-            self.display.change_brightness()
+    def change_brightness(self):
+        pass
+
+
+def detect_display():
+    hatdir = "/proc/device-tree/hat"
+    product_file = f"{hatdir}/product"
+    vendor_file = f"{hatdir}/vendor"
+    if os.path.exists(product_file) and os.path.exists(vendor_file):
+        with open(product_file) as f:
+            p = f.read()
+        with open(vendor_file) as f:
+            v = f.read()
+        app_logger.info(f"{product_file}: {p}")
+        app_logger.info(f"{vendor_file}: {v}")
+        # set display
+        if p.find("Adafruit PiTFT HAT - 2.4 inch Resistive Touch") == 0:
+            return "PiTFT"
+        elif (p.find("PaPiRus ePaper HAT") == 0) and (v.find("Pi Supply") == 0):
+            return "Papirus"
+    return None
+
+
+def init_display(config):
+    # default dummy display
+
+    display = Display(config)
+
+    if not config.G_IS_RASPI:
+        config.G_DISPLAY = "None"
+        return display
+
+    auto_detect = detect_display()
+
+    if auto_detect is not None:
+        config.G_DISPLAY = auto_detect
+
+    if config.G_DISPLAY == "PiTFT":
+        from .pitft_28_r import _SENSOR_DISPLAY, PiTFT28r
+
+        if _SENSOR_DISPLAY:
+            display = PiTFT28r(config)
+    elif config.G_DISPLAY in ("MIP", "MIP_640"):
+        from .mip_display import _SENSOR_DISPLAY, MipDisplay
+
+        if _SENSOR_DISPLAY:
+            display = MipDisplay(config, SUPPORTED_DISPLAYS[config.G_DISPLAY])
+    elif config.G_DISPLAY in ("MIP_Sharp", "MIP_Sharp_320"):
+        from .mip_sharp_display import _SENSOR_DISPLAY, MipSharpDisplay
+
+        if _SENSOR_DISPLAY:
+            display = MipSharpDisplay(config, SUPPORTED_DISPLAYS[config.G_DISPLAY])
+    elif config.G_DISPLAY == "Papirus":
+        from .papirus_display import _SENSOR_DISPLAY, PapirusDisplay
+
+        if _SENSOR_DISPLAY:
+            display = PapirusDisplay(config)
+    elif config.G_DISPLAY == "DFRobot_RPi_Display":
+        from .dfrobot_rpi_display import _SENSOR_DISPLAY, DFRobotRPiDisplay
+
+        if _SENSOR_DISPLAY:
+            display = DFRobotRPiDisplay(config)
+
+    return display

--- a/modules/display/mip_display.py
+++ b/modules/display/mip_display.py
@@ -53,6 +53,7 @@ class MipDisplay(Display):
     mip_display_cpp = None
 
     has_touch = False
+    send = True
 
     size = (400, 240)
 

--- a/modules/display/mip_display.py
+++ b/modules/display/mip_display.py
@@ -4,6 +4,7 @@ import asyncio
 import numpy as np
 
 from logger import app_logger
+from .display_core import Display
 
 _SENSOR_DISPLAY = False
 MODE = "Python"
@@ -42,8 +43,7 @@ UPDATE_MODE = 0x80
 GPIO_BACKLIGHT_FREQ = 64
 
 
-class MipDisplay:
-    config = None
+class MipDisplay(Display):
     pi = None
     spi = None
     interval = 0.25
@@ -52,21 +52,21 @@ class MipDisplay:
     brightness = 0
     mip_display_cpp = None
 
-    def __init__(self, config):
-        self.config = config
+    has_touch = False
 
-        if not _SENSOR_DISPLAY:
-            return
+    size = (400, 240)
+
+    def __init__(self, config, size=None):
+        super().__init__(config)
+
+        if size:
+            self.size = size
 
         if MODE == "Cython":
             self.conv_color = conv_3bit_color
         elif MODE == "Cython_full":
-            self.mip_display_cpp = MipDisplay_CPP(
-                self.config.G_DISPLAY_PARAM["SPI_CLOCK"]
-            )
-            self.mip_display_cpp.set_screen_size(
-                self.config.G_WIDTH, self.config.G_HEIGHT
-            )
+            self.mip_display_cpp = MipDisplay_CPP(config.G_DISPLAY_PARAM["SPI_CLOCK"])
+            self.mip_display_cpp.set_screen_size(self.size[0], self.size[1])
             self.update = self.mip_display_cpp.update
             self.set_brightness = self.mip_display_cpp.set_brightness
             self.inversion = self.mip_display_cpp.inversion
@@ -79,7 +79,7 @@ class MipDisplay:
 
         # spi
         self.pi = pigpio.pi()
-        self.spi = self.pi.spi_open(0, self.config.G_DISPLAY_PARAM["SPI_CLOCK"], 0)
+        self.spi = self.pi.spi_open(0, config.G_DISPLAY_PARAM["SPI_CLOCK"], 0)
 
         self.pi.set_mode(GPIO_DISP, pigpio.OUTPUT)
         self.pi.set_mode(GPIO_SCS, pigpio.OUTPUT)
@@ -93,22 +93,20 @@ class MipDisplay:
         # backlight
         self.pi.set_mode(GPIO_BACKLIGHT, pigpio.OUTPUT)
         self.pi.hardware_PWM(GPIO_BACKLIGHT, GPIO_BACKLIGHT_FREQ, 0)
-        if self.config.G_USE_AUTO_BACKLIGHT:
+        if config.G_USE_AUTO_BACKLIGHT:
             self.brightness_index = len(self.brightness_table)
         else:
             self.brightness_index = 0
 
     def init_buffer(self):
-        self.buff_width = int(self.config.G_WIDTH * 3 / 8) + 2  # for 3bit update mode
-        self.img_buff_rgb8 = np.empty(
-            (self.config.G_HEIGHT, self.buff_width), dtype="uint8"
-        )
-        self.pre_img = np.zeros((self.config.G_HEIGHT, self.buff_width), dtype="uint8")
+        self.buff_width = int(self.size[0] * 3 / 8) + 2  # for 3bit update mode
+        self.img_buff_rgb8 = np.empty((self.size[1], self.buff_width), dtype="uint8")
+        self.pre_img = np.zeros((self.size[1], self.buff_width), dtype="uint8")
         self.img_buff_rgb8[:, 0] = UPDATE_MODE
-        self.img_buff_rgb8[:, 1] = np.arange(self.config.G_HEIGHT)
+        self.img_buff_rgb8[:, 1] = np.arange(self.size[1])
         # for MIP_640
         self.img_buff_rgb8[:, 0] = self.img_buff_rgb8[:, 0] + (
-            np.arange(self.config.G_HEIGHT) >> 8
+            np.arange(self.size[1]) >> 8
         )
 
     def start_coroutine(self):
@@ -131,8 +129,6 @@ class MipDisplay:
         time.sleep(0.000006)
 
     def blink(self, sec):
-        if not _SENSOR_DISPLAY:
-            return
         s = sec
         state = True
         while s > 0:
@@ -149,8 +145,6 @@ class MipDisplay:
         self.no_update()
 
     def inversion(self, sec):
-        if not _SENSOR_DISPLAY:
-            return
         s = sec
         state = True
         while s > 0:
@@ -185,8 +179,9 @@ class MipDisplay:
             self.draw_queue.task_done()
 
     def update(self, im_array, direct_update):
-        if not _SENSOR_DISPLAY or self.config.G_QUIT:
-            return
+        # direct update not yet supported for MPI_640
+        if direct_update and self.config.G_DISPLAY in ("MIP_640",):
+            direct_update = False
 
         # self.config.check_time("mip_update start")
         self.img_buff_rgb8[:, 2:] = self.conv_color(im_array)
@@ -196,7 +191,7 @@ class MipDisplay:
         diff_lines = np.where(
             np.sum((self.img_buff_rgb8 == self.pre_img), axis=1) != self.buff_width
         )[0]
-        # print("diff ", int(len(diff_lines)/self.config.G_HEIGHT*100), "%")
+        # print("diff ", int(len(diff_lines)/self.size[1]*100), "%")
         # print(" ")
 
         if not len(diff_lines):
@@ -230,7 +225,7 @@ class MipDisplay:
 
     def conv_2bit_color_py(self, im_array):
         return np.packbits(
-            (im_array >= 128).reshape(self.config.G_HEIGHT, self.config.G_WIDTH * 3),
+            (im_array >= 128).reshape(self.size[1], self.size[0] * 3),
             axis=1,
         )
 
@@ -271,9 +266,7 @@ class MipDisplay:
             ]
         ] = 1
 
-        return np.packbits(
-            im_array_bin.reshape(self.config.G_HEIGHT, self.config.G_WIDTH * 3), axis=1
-        )
+        return np.packbits(im_array_bin.reshape(self.size[1], self.size[0] * 3), axis=1)
 
     def change_brightness(self):
         # brightness is changing as following,
@@ -290,14 +283,12 @@ class MipDisplay:
             self.set_brightness(b)
 
     def set_brightness(self, b):
-        if not _SENSOR_DISPLAY or b == self.brightness or self.config.G_QUIT:
+        if b == self.brightness or self.config.G_QUIT:
             return
         self.pi.hardware_PWM(GPIO_BACKLIGHT, GPIO_BACKLIGHT_FREQ, b * 10000)
         self.brightness = b
 
     def backlight_blink(self):
-        if not _SENSOR_DISPLAY:
-            return
         for x in range(2):
             for pw in range(0, 100, 1):
                 self.pi.hardware_PWM(GPIO_BACKLIGHT, GPIO_BACKLIGHT_FREQ, pw * 10000)
@@ -307,9 +298,6 @@ class MipDisplay:
                 time.sleep(0.05)
 
     def quit(self):
-        if not _SENSOR_DISPLAY:
-            return
-
         asyncio.create_task(self.draw_queue.put(None))
         self.set_brightness(0)
         self.clear()
@@ -319,3 +307,9 @@ class MipDisplay:
 
         self.pi.spi_close(self.spi)
         self.pi.stop()
+
+    def screen_flash_long(self):
+        return self.inversion(0.8)
+
+    def screen_flash_short(self):
+        return self.inversion(0.3)

--- a/modules/display/mip_sharp_display.py
+++ b/modules/display/mip_sharp_display.py
@@ -35,6 +35,7 @@ class MipSharpDisplay(Display):
 
     has_color = False
     has_touch = False
+    send = True
 
     size = (400, 240)
 

--- a/modules/display/papirus_display.py
+++ b/modules/display/papirus_display.py
@@ -1,6 +1,7 @@
 from PIL import Image
 
 from logger import app_logger
+from .display_core import Display
 
 _SENSOR_DISPLAY = False
 try:
@@ -14,21 +15,23 @@ except ImportError:
 app_logger.info(f"PAPIRUS E-INK DISPLAY: {_SENSOR_DISPLAY}")
 
 
-class PapirusDisplay:
-    config = None
+class PapirusDisplay(Display):
     papirus = None
 
-    def __init__(self, config):
-        self.config = config
+    has_color = False
+    has_touch = False
 
-        if _SENSOR_DISPLAY:
-            self.papirus = Papirus(rotation=180)
-            self.clear()
+    size = (264, 176)
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.papirus = Papirus(rotation=180)
+        self.clear()
 
     def clear(self):
         self.papirus.clear()
 
-    def update(self, im_array):
+    def update(self, im_array, direct_update=False):
         self.papirus.display(
             Image.frombytes(
                 "1", (im_array.shape[1] * 8, im_array.shape[0]), (~im_array).tobytes()
@@ -37,5 +40,4 @@ class PapirusDisplay:
         self.papirus.fast_update()
 
     def quit(self):
-        if _SENSOR_DISPLAY:
-            self.clear()
+        self.clear()

--- a/modules/display/papirus_display.py
+++ b/modules/display/papirus_display.py
@@ -20,6 +20,7 @@ class PapirusDisplay(Display):
 
     has_color = False
     has_touch = False
+    send = True
 
     size = (264, 176)
 

--- a/modules/display/pitft_28_r.py
+++ b/modules/display/pitft_28_r.py
@@ -24,8 +24,6 @@ class PiTFT28r(Display):
 
     size = (320, 240)
 
-    send = False
-
     def __init__(self, config):
         super().__init__(config)
         self.clear()

--- a/modules/display/pitft_28_r.py
+++ b/modules/display/pitft_28_r.py
@@ -1,17 +1,13 @@
 from logger import app_logger
 from modules.utils.cmd import exec_cmd
+from .display_core import Display
 
 _SENSOR_DISPLAY = True
 
 app_logger.info(f"PiTFT 2.8(r): {_SENSOR_DISPLAY}")
 
-# SCREEN
-SCREEN_WIDTH = 320
-SCREEN_HEIGHT = 240
 
-
-class PiTFT28r:
-    config = None
+class PiTFT28r(Display):
     spi = None
 
     # brightness
@@ -26,23 +22,23 @@ class PiTFT28r:
     # brightness_cmd_init = ["/usr/bin/gpio", "-g", "mode", "18", "pwm"]
     # brightness_cmd_base = ["/usr/bin/gpio", "-g", "pwm", "18"]
 
-    def __init__(self, config):
-        self.config = config
+    size = (320, 240)
 
-        if _SENSOR_DISPLAY:
-            self.clear()
+    send = False
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.clear()
 
     def clear(self):
         pass
 
     def quit(self):
-        if _SENSOR_DISPLAY:
-            self.clear()
-            # GPIO.output(GPIO_DISP, 1)
-            # time.sleep(0.1)
+        self.clear()
+        # GPIO.output(GPIO_DISP, 1)
+        # time.sleep(0.1)
 
     def change_brightness(self):
-        if _SENSOR_DISPLAY:
-            self.brightness_index = not self.brightness_index
-            cmd = self.brightness_cmd[int(self.brightness_index)]
-            exec_cmd(cmd)
+        self.brightness_index = not self.brightness_index
+        cmd = self.brightness_cmd[int(self.brightness_index)]
+        exec_cmd(cmd)

--- a/modules/logger_core.py
+++ b/modules/logger_core.py
@@ -489,7 +489,14 @@ class LoggerCore:
         # update lap stats if value is not Null
         for k, v in value.items():
             # skip when null value(np.nan)
-            if k not in ["heart_rate", "cadence", "speed", "power", "distance", "accumulated_power"]:
+            if k not in [
+                "heart_rate",
+                "cadence",
+                "speed",
+                "power",
+                "distance",
+                "accumulated_power",
+            ]:
                 continue
             if np.isnan(v):
                 continue

--- a/modules/pyqt/graph/pyqt_course_profile.py
+++ b/modules/pyqt/graph/pyqt_course_profile.py
@@ -30,7 +30,7 @@ class CourseProfileGraphWidget(BaseMapWidget):
         # map
         self.layout.addWidget(self.plot, 0, 0, 3, 3)
 
-        if self.config.display.has_touch():
+        if self.config.display.has_touch:
             # zoom
             self.layout.addWidget(self.buttons["zoomdown"], 0, 0)
             self.layout.addWidget(self.buttons["lock"], 1, 0)

--- a/modules/pyqt/graph/pyqt_map.py
+++ b/modules/pyqt/graph/pyqt_map.py
@@ -168,7 +168,7 @@ class MapWidget(BaseMapWidget):
         # map
         self.layout.addWidget(self.plot, 0, 0, 4, 3)
 
-        if self.config.display.has_touch():
+        if self.config.display.has_touch:
             # zoom
             self.layout.addWidget(self.buttons["zoomdown"], 0, 0)
             self.layout.addWidget(self.buttons["lock"], 1, 0)

--- a/modules/pyqt/menu/pyqt_adjust_widget.py
+++ b/modules/pyqt/menu/pyqt_adjust_widget.py
@@ -99,7 +99,7 @@ class AdjustWidget(MenuWidget):
         set_button.clicked.connect(self.set_value)
         self.menu_layout.addWidget(set_button, 2, 5)
 
-        if not self.config.display.has_touch():
+        if not self.config.display.has_touch:
             self.focus_widget = num_buttons[1]
 
         self.init_extra()

--- a/modules/pyqt/menu/pyqt_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_menu_widget.py
@@ -110,7 +110,7 @@ class MenuWidget(QtWidgets.QWidget):
                 self.menu_layout.addWidget(MenuButton("dummy", "", self.config))
 
         # set first focus
-        if not self.config.display.has_touch():
+        if not self.config.display.has_touch:
             self.focus_widget = self.buttons[buttons[0][0]]
 
     def setup_menu(self):

--- a/modules/pyqt/menu/pyqt_sensor_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_sensor_menu_widget.py
@@ -50,7 +50,7 @@ class ANTMenuWidget(MenuWidget):
         for antName in self.config.G_ANT["ORDER"]:
             self.buttons[antName].setText(self.get_button_state(antName))
 
-        if not self.config.display.has_touch():
+        if not self.config.display.has_touch:
             self.focus_widget = self.buttons[self.config.G_ANT["ORDER"][0]]
 
     def get_button_state(self, antName):

--- a/modules/pyqt/pyqt_screen_widget.py
+++ b/modules/pyqt/pyqt_screen_widget.py
@@ -67,7 +67,7 @@ class ScreenWidget(QtWidgets.QWidget):
         self.add_items()
 
         # this depends on max_height so has to be done after add_items that recalculate it
-        self.set_font_size(self.config.G_HEIGHT)
+        self.set_font_size(self.config.display.resolution[1])
 
     # call from on_change_main_page in gui_pyqt.py
     def start(self):

--- a/modules/sensor_core.py
+++ b/modules/sensor_core.py
@@ -576,10 +576,8 @@ class SensorCore:
 
                 # auto backlight
                 if self.config.G_IS_RASPI and self.config.G_USE_AUTO_BACKLIGHT:
-                    if (
-                        self.config.G_DISPLAY in ("MIP", "MIP_640")
-                        and self.config.display.send_display
-                        and not np.isnan(v["I2C"]["light"])
+                    if self.config.G_DISPLAY in ("MIP", "MIP_640") and not np.isnan(
+                        v["I2C"]["light"]
                     ):
                         if v["I2C"]["light"] <= self.config.G_AUTO_BACKLIGHT_CUTOFF:
                             self.config.display.display.set_brightness(3)

--- a/modules/sensor_core.py
+++ b/modules/sensor_core.py
@@ -580,9 +580,9 @@ class SensorCore:
                         v["I2C"]["light"]
                     ):
                         if v["I2C"]["light"] <= self.config.G_AUTO_BACKLIGHT_CUTOFF:
-                            self.config.display.display.set_brightness(3)
+                            self.config.display.set_brightness(3)
                         else:
-                            self.config.display.display.set_brightness(0)
+                            self.config.display.set_brightness(0)
                     if self.config.G_MANUAL_STATUS == "START":
                         if v["I2C"]["light"] <= self.config.G_AUTO_BACKLIGHT_CUTOFF:
                             self.sensor_ant.set_light_mode("FLASH_LOW", auto=True)

--- a/pizero_bikecomputer.py
+++ b/pizero_bikecomputer.py
@@ -25,10 +25,10 @@ def main():
 
     # display
     with timers[2]:
-        from modules.display.display_core import Display
+        from modules.display.display_core import init_display
 
     with timers[3]:
-        config.set_display(Display(config, {}))
+        config.set_display(init_display(config))
 
     # minimal gui
     with timers[4]:


### PR DESCRIPTION
Hey,

Small code reorg that I had in a branch. Kinda similar to GPS refactor, it simplifies a bit the code. but the 'config' object is still passed down (and modified)
To be fair, it can probably go a bit further, the 'blockers' are the reading G_QUIT, and G_AUTOBACKLIGHT (which is even modified).
1. Is checking G_QUIT in update still necessary ? What is it needed ?
2. I don't really get the code of change_brightness in MIP display (and can't test it). How come calling change_brightness can switch G_USE_AUTO_BACKLIGHT on /off?