### PR TITLE
split (app) state and settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ __pycache__/
 *.so
 a.out
 setting.conf
-setting.pickle
+state.pickle
 layout.yaml
 map.yaml
 nohup.out

--- a/doc/software_installation.md
+++ b/doc/software_installation.md
@@ -29,7 +29,7 @@
     - [System](#System)
   - [Settings](#settings)
     - [setting.conf](#settingconf)
-    - [setting.pickle](#settingpickle)
+    - [state.pickle](#statepickle)
     - [layout.yaml](#layoutyaml)
     - [map.yaml](#mapyaml)
     - [config.py](#configpy)
@@ -737,7 +737,7 @@ If you want to correct the altitude using a barometric pressure sensor, set your
 If you want to use ThingsBoard dashboard, set your `token` of the Thingboard device access token.
 
 
-### setting.pickle
+### state.pickle
 
 It stores temporary variables such as values for quick recovery in the event of a power failure and sensor calibration results.
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -15,6 +15,7 @@ from PIL import Image
 from logger import CustomRotatingFileHandler, app_logger
 from modules.helper.setting import Setting
 from modules.button_config import Button_Config
+from modules.state import AppState
 from modules.utils.cmd import (
     exec_cmd,
     exec_cmd_return_value,
@@ -625,6 +626,7 @@ class Config:
     bt_pan = None
     ble_uart = None
     setting = None
+    state = None
     gui = None
     gui_config = None
     boot_time = 0
@@ -660,9 +662,9 @@ class Config:
             app_logger.setLevel(logging.DEBUG)
             app_logger.debug(args)
 
-        # read setting.conf and settings.pickle
+        # read setting.conf and state.pickle
         self.setting = Setting(self)
-        self.setting.read()
+        self.state = AppState()
 
         # make sure all folders exist
         os.makedirs(self.G_SCREENSHOT_DIR, exist_ok=True)
@@ -801,8 +803,8 @@ class Config:
                     self.logger.sensor.sensor_gps,
                     self.gui,
                     (
-                        self.setting.get_config_pickle("GB", False),
-                        self.setting.get_config_pickle("GB_gps", False),
+                        self.state.get_value("GB", False),
+                        self.state.get_value("GB_gps", False),
                     ),
                 )
 
@@ -818,15 +820,13 @@ class Config:
 
         # resume BT / thingsboard
         if self.G_IS_RASPI:
-            self.G_BT_USE_ADDRESS = self.setting.get_config_pickle(
+            self.G_BT_USE_ADDRESS = self.state.get_value(
                 "G_BT_USE_ADDRESS", self.G_BT_USE_ADDRESS
             )
-            self.G_THINGSBOARD_API["STATUS"] = self.setting.get_config_pickle(
+            self.G_THINGSBOARD_API["STATUS"] = self.state.get_value(
                 "G_THINGSBOARD_API_STATUS", self.G_THINGSBOARD_API["STATUS"]
             )
-            self.G_THINGSBOARD_API[
-                "AUTO_UPLOAD_VIA_BT"
-            ] = self.setting.get_config_pickle(
+            self.G_THINGSBOARD_API["AUTO_UPLOAD_VIA_BT"] = self.state.get_value(
                 "AUTO_UPLOAD_VIA_BT", self.G_THINGSBOARD_API["AUTO_UPLOAD_VIA_BT"]
             )
             # resume BT tethering
@@ -955,7 +955,7 @@ class Config:
 
         await self.logger.quit()
         self.setting.write_config()
-        self.setting.delete_config_pickle()
+        self.state.delete()
 
         await asyncio.sleep(0.5)
         await self.kill_tasks()

--- a/modules/helper/api.py
+++ b/modules/helper/api.py
@@ -371,9 +371,7 @@ class api:
             return False
 
         try:
-            saved_session = self.config.setting.get_config_pickle(
-                "garmin_session", None
-            )
+            saved_session = self.config.state.get_value("garmin_session", None)
             garmin_api = Garmin(session_data=saved_session)
             garmin_api.login()
         except (FileNotFoundError, GarminConnectAuthenticationError):
@@ -383,8 +381,8 @@ class api:
                     self.config.G_GARMINCONNECT_API["PASSWORD"],
                 )
                 garmin_api.login()
-                self.config.set_config_pickle(
-                    "garmin_session", garmin_api.session_data, quick_apply=True
+                self.config.state.set_value(
+                    "garmin_session", garmin_api.session_data, force_apply=True
                 )
             except (
                 GarminConnectConnectionError,

--- a/modules/logger_core.py
+++ b/modules/logger_core.py
@@ -137,7 +137,7 @@ class LoggerCore:
             return
 
         # resume START/STOP status if temporary values exist
-        self.config.G_MANUAL_STATUS = self.config.setting.get_config_pickle(
+        self.config.G_MANUAL_STATUS = self.config.state.get_value(
             "G_MANUAL_STATUS", self.config.G_MANUAL_STATUS
         )
         if self.config.G_MANUAL_STATUS == "START":
@@ -336,8 +336,8 @@ class LoggerCore:
             if self.config.gui is not None:
                 self.config.gui.change_start_stop_button(self.config.G_MANUAL_STATUS)
 
-        self.config.setting.set_config_pickle(
-            "G_MANUAL_STATUS", self.config.G_MANUAL_STATUS, quick_apply=True
+        self.config.state.set_value(
+            "G_MANUAL_STATUS", self.config.G_MANUAL_STATUS, force_apply=True
         )
 
         # send online
@@ -443,7 +443,7 @@ class LoggerCore:
         app_logger.info(f"DELETE : {(datetime.datetime.now() - t).total_seconds()} sec")
 
         # reset temporary values
-        self.config.setting.reset_config_pickle()
+        self.config.state.reset()
 
         # reset accumulated values
         self.sensor.reset()

--- a/modules/pyqt/menu/pyqt_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_menu_widget.py
@@ -421,7 +421,7 @@ class LiveTrackMenuWidget(MenuWidget):
             self.config.G_THINGSBOARD_API["STATUS"] = not self.config.G_THINGSBOARD_API[
                 "STATUS"
             ]
-            self.config.setting.set_config_pickle(
+            self.config.state.set_value(
                 "G_THINGSBOARD_API_STATUS", self.config.G_THINGSBOARD_API["STATUS"]
             )
         self.buttons["Live Track"].change_toggle(
@@ -433,7 +433,7 @@ class LiveTrackMenuWidget(MenuWidget):
             self.config.G_THINGSBOARD_API[
                 "AUTO_UPLOAD_VIA_BT"
             ] = not self.config.G_THINGSBOARD_API["AUTO_UPLOAD_VIA_BT"]
-            self.config.setting.set_config_pickle(
+            self.config.state.set_value(
                 "AUTO_UPLOAD_VIA_BT",
                 self.config.G_THINGSBOARD_API["AUTO_UPLOAD_VIA_BT"],
             )

--- a/modules/pyqt/menu/pyqt_system_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_system_menu_widget.py
@@ -102,12 +102,12 @@ class NetworkMenuWidget(MenuWidget):
         status = await self.config.ble_uart.on_off_uart_service()
         self.buttons["Gadgetbridge"].change_toggle(status)
         self.buttons["Get Location"].onoff_button(status)
-        self.config.setting.set_config_pickle("GB", status, quick_apply=True)
+        self.config.state.set_value("GB", status, force_apply=True)
 
     def onoff_gadgetbridge_gps(self):
         status = self.config.ble_uart.on_off_gadgetbridge_gps()
         self.buttons["Get Location"].change_toggle(status)
-        self.config.setting.set_config_pickle("GB_gps", status, quick_apply=True)
+        self.config.state.set_value("GB_gps", status, force_apply=True)
 
 
 class DebugMenuWidget(MenuWidget):
@@ -186,9 +186,7 @@ class BluetoothTetheringListWidget(ListWidget):
     async def button_func_extra(self):
         self.config.G_BT_USE_ADDRESS = self.selected_item.title_label.text()
         # save for restart
-        self.config.setting.set_config_pickle(
-            "G_BT_USE_ADDRESS", self.config.G_BT_USE_ADDRESS
-        )
+        self.config.state.set_value("G_BT_USE_ADDRESS", self.config.G_BT_USE_ADDRESS)
 
         if self.run_bt_tethering:
             await self.config.bluetooth_tethering()

--- a/modules/sensor/ant/ant_device_power.py
+++ b/modules/sensor/ant/ant_device_power.py
@@ -181,7 +181,7 @@ class ANT_Device_Power(ant_device.ANT_Device):
         # on_data timestamp
         values["on_data_timestamp"] = t
         # store raw power
-        self.config.setting.set_config_pickle("ant+_power_values_16", power_values[1])
+        self.config.state.set_value("ant+_power_values_16", power_values[1])
 
     def on_data_power_0x11(self, data, power_values, pre_values, values):
         # (page), evt_count, wheel_ticks, x, wheel period(2byte), accumulated power(2byte)
@@ -198,7 +198,7 @@ class ANT_Device_Power(ant_device.ANT_Device):
             values["on_data_timestamp"] = t
             values["power"] = 0
 
-            pre_pwr_value = self.config.setting.get_config_pickle(
+            pre_pwr_value = self.config.state.get_value(
                 "ant+_power_values_17", pre_values
             )
             pwr_diff = pre_values[1] - pre_pwr_value[1]
@@ -267,7 +267,7 @@ class ANT_Device_Power(ant_device.ANT_Device):
         values["on_data_timestamp"] = t
 
         # store raw power
-        self.config.setting.set_config_pickle("ant+_power_values_17", power_values)
+        self.config.state.set_value("ant+_power_values_17", power_values)
 
     def on_data_power_0x12(self, data, power_values, pre_values, values):
         # (page), x, x, cadence, period(2byte), accumulatd power(2byte)
@@ -280,7 +280,7 @@ class ANT_Device_Power(ant_device.ANT_Device):
             values["on_data_timestamp"] = t
             values["power"] = 0
 
-            pre_pwr_value = self.config.setting.get_config_pickle(
+            pre_pwr_value = self.config.state.get_value(
                 "ant+_power_values_18", pre_values[1]
             )
             diff = pre_values[1] - pre_pwr_value
@@ -338,4 +338,4 @@ class ANT_Device_Power(ant_device.ANT_Device):
         values["on_data_timestamp"] = t
 
         # store raw power
-        self.config.setting.set_config_pickle("ant+_power_values_18", power_values[1])
+        self.config.state.set_value("ant+_power_values_18", power_values[1])

--- a/modules/sensor/ant/ant_device_speed_cadence.py
+++ b/modules/sensor/ant/ant_device_speed_cadence.py
@@ -40,7 +40,7 @@ class ANT_Device_Speed_Cadence(ant_device.ANT_Device):
             self.values["cadence"] = 0
             self.values["on_data_timestamp"] = t
 
-            pre_speed_value = self.config.setting.get_config_pickle(
+            pre_speed_value = self.config.state.get_value(
                 self.pickle_key, self.pre_values[3]
             )
             diff = self.pre_values[3] - pre_speed_value
@@ -94,7 +94,7 @@ class ANT_Device_Speed_Cadence(ant_device.ANT_Device):
                 f"ANT+ S&C(speed) err: {datetime.datetime.now().strftime('%Y%m%d %H:%M:%S')} {self.delta}",
             )
         # store raw speed
-        self.config.setting.set_config_pickle(self.pickle_key, self.sc_values[3])
+        self.config.state.set_value(self.pickle_key, self.sc_values[3])
 
         # cadence
         if self.delta[0] > 0 and 0 <= self.delta[1] < 6553:  # for spike
@@ -231,7 +231,7 @@ class ANT_Device_Speed(ANT_Device_Cadence):
         self.const = self.config.G_WHEEL_CIRCUMFERENCE
 
     def resumeAccumulatedValue(self):
-        pre_speed_value = self.config.setting.get_config_pickle(
+        pre_speed_value = self.config.state.get_value(
             self.pickle_key, self.pre_values[1]
         )
         diff = self.pre_values[1] - pre_speed_value
@@ -249,4 +249,4 @@ class ANT_Device_Speed(ANT_Device_Cadence):
             # unit: m
             self.values["distance"] += self.config.G_WHEEL_CIRCUMFERENCE * self.delta[1]
         # store raw speed
-        self.config.setting.set_config_pickle(self.pickle_key, self.sc_values[1])
+        self.config.state.set_value(self.pickle_key, self.sc_values[1])

--- a/modules/sensor/sensor_i2c.py
+++ b/modules/sensor/sensor_i2c.py
@@ -213,17 +213,14 @@ class SensorI2C(Sensor):
 
         self.reset()
 
-        # store temporary values
-        self.sealevel_pa = self.config.setting.get_config_pickle(
-            "sealevel_pa", self.sealevel_pa
-        )
-        self.sealevel_temp = self.config.setting.get_config_pickle(
+        self.sealevel_pa = self.config.state.get_value("sealevel_pa", self.sealevel_pa)
+        self.sealevel_temp = self.config.state.get_value(
             "sealevel_temp", self.sealevel_temp
         )
-        self.values_mod["mag_min"] = self.config.setting.get_config_pickle(
+        self.values_mod["mag_min"] = self.config.state.get_value(
             "mag_min" + "_" + self.sensor_label["MAG"], self.values_mod["mag_min"]
         )
-        self.values_mod["mag_max"] = self.config.setting.get_config_pickle(
+        self.values_mod["mag_max"] = self.config.state.get_value(
             "mag_max" + "_" + self.sensor_label["MAG"], self.values_mod["mag_max"]
         )
 
@@ -670,11 +667,11 @@ class SensorI2C(Sensor):
         )
         # store
         if np.any(pre_min != self.values_mod["mag_min"]):
-            self.config.setting.set_config_pickle(
+            self.config.state.set_value(
                 "mag_min" + "_" + self.sensor_label["MAG"], self.values_mod["mag_min"]
             )
         if np.any(pre_max != self.values_mod["mag_max"]):
-            self.config.setting.set_config_pickle(
+            self.config.state.set_value(
                 "mag_max" + "_" + self.sensor_label["MAG"], self.values_mod["mag_max"]
             )
         # hard iron distortion
@@ -1121,11 +1118,9 @@ class SensorI2C(Sensor):
         self.sealevel_pa = self.values["pressure"] * pow(
             (self.sealevel_temp - 0.0065 * alt) / self.sealevel_temp, -5.257
         )
-        self.config.setting.set_config_pickle(
-            "sealevel_pa", self.sealevel_pa, quick_apply=False
-        )
-        self.config.setting.set_config_pickle(
-            "sealevel_temp", self.sealevel_temp, quick_apply=True
+        self.config.state.set_value("sealevel_pa", self.sealevel_pa)
+        self.config.state.set_value(
+            "sealevel_temp", self.sealevel_temp, force_apply=True
         )
 
         # reset historical altitude

--- a/modules/state.py
+++ b/modules/state.py
@@ -1,0 +1,58 @@
+import pickle
+from datetime import datetime
+
+
+# store temporary values. unreadable and uneditable.
+class AppState:
+    interval = 10  # [s]
+
+    last_write_time = datetime.utcnow()
+    pickle_file = "state.pickle"
+    values = None
+
+    def __init__(self):
+        try:
+            with open(self.pickle_file, "rb") as f:
+                self.values = pickle.load(f)
+        except FileNotFoundError:
+            self.values = {}
+
+    def set_value(self, key, value, force_apply=False):
+        self.values[key] = value
+
+        now = datetime.utcnow()
+
+        if (
+            not force_apply
+            and (now - self.last_write_time).total_seconds() < self.interval
+        ):
+            return
+
+        with open(self.pickle_file, "wb") as f:
+            pickle.dump(self.values, f)
+        self.last_write_time = now
+
+    def get_value(self, key, default_value):
+        return self.values.get(key, default_value)
+
+    # reset
+    #   mag_min, mag_max: keep until power is turned off
+    def reset(self):
+        for k, v in list(self.values.items()):
+            if "mag" in k:
+                continue
+            del self.values[k]
+        with open(self.pickle_file, "wb") as f:
+            pickle.dump(self.values, f)
+
+    # quit (poweroff)
+    #   ant+_sc_values, ant+_spd_values,
+    #   ant+_power_values_16, ant+_power_values_17, ant+_power_values_18
+    #   GB_status, GB_gps:
+    #   keep in case of sudden shutdown or killed (not via quit()). erase on reset.
+    def delete(self):
+        for k, v in list(self.values.items()):
+            if "ant+" in k or k.startswith("GB"):
+                del self.values[k]
+        with open(self.pickle_file, "wb") as f:
+            pickle.dump(self.values, f)


### PR DESCRIPTION
As discussed, it just split the settings and the app state in two different objects.
It probably fixes also saving the garmin_session in api. It was probably crashing because the code was: 
```
self.config.set_config_pickle(
```
(instead of self.config.setting.set_config_pickle)