### PR TITLE
Add Option for Horizontal or Vertical Display Orientation

### DIFF
--- a/doc/software_installation.md
+++ b/doc/software_installation.md
@@ -69,7 +69,6 @@ Here is [my setup guide in Japanese](https://qiita.com/hishi/items/8bdfd9d72fa8f
 
 Install in the home directory of default user "pi". Also, your Raspberry Pi is connected to internet and updated with `apt update & apt upgrade`.
 
-
 ```
 $ cd
 $ git clone https://github.com/hishizuka/pizero_bikecomputer.git
@@ -87,7 +86,7 @@ Assume Serial interface is on and login shell is off in raspi-config and GPS dev
 
 ```
 $ sudo apt install gpsd gpsd-clients
-$ sudo pip3 install gps3 timezonefinder 
+$ sudo pip3 install gps3 timezonefinder
 $ sudo cp install/etc/default/gpsd /etc/default/gpsd
 $ sudo systemctl enable gpsd
 ```
@@ -104,14 +103,12 @@ $ sudo pip3 install timezonefinder pa1010d
 
 Check with [pa1010d example program](https://github.com/pimoroni/pa1010d-python/blob/master/examples/latlon.py)
 
-
 ### ANT+ USB dongle
 
 ```
 $ sudo apt install libusb-1.0-0 python3-usb
 $ sudo pip3 install git+https://github.com/hishizuka/openant.git
 ```
- 
 
 ### Display
 
@@ -155,7 +152,6 @@ Follow [official setup guide](https://github.com/PiSupply/PaPiRus)
 
 Follow [official setup guide](https://wiki.dfrobot.com/Raspberry_Pi_e-ink_Display_Module_SKU%3A_DFR0591) and install manually.
 
-
 ### I2C sensors
 
 Assume I2C interface is on in raspi-config.
@@ -165,32 +161,32 @@ Assume I2C interface is on in raspi-config.
 Install pip packages of the sensors you own.
 
 Here is an example.
+
 ```
 $ sudo pip3 install adafruit-circuitpython-bmp280
 ```
 
-| Manufacturer | Sensor | additional pip package |
-|:-|:-|:-|
-| [Pimoroni](https://shop.pimoroni.com) | [Enviro pHAT](https://shop.pimoroni.com/products/enviro-phat) | None |
-| [Adafruit](https://www.adafruit.com) | [BMP280](https://www.adafruit.com/product/2651) | None |
-| [Adafruit](https://www.adafruit.com) | [BMP390](https://www.adafruit.com/product/4816) | None |
-| [Sparkfun](https://www.sparkfun.com/) | [BMP581](https://www.sparkfun.com/products/20170) | None |
-| [Adafruit](https://www.adafruit.com) | [LPS33HW](https://www.adafruit.com/product/4414) | adafruit-circuitpython-lps35hw |
-| [Strawberry Linux](https://strawberry-linux.com) | [LPS33HW](https://strawberry-linux.com/catalog/items?code=12133) | None |
-| [DFRobot](https://www.dfrobot.com) | [BMX160+BMP388](https://www.dfrobot.com/product-1928.html) | BMX160(*1) | 
-| [Adafruit](https://www.adafruit.com) | [LSM6DS33 + LIS3MDL](https://www.adafruit.com/product/4485) | adafruit-circuitpython-lsm6ds adafruit-circuitpython-lis3mdl |
-| [Sparkfun](https://www.sparkfun.com/) | [ISM330DHCX + MMC5983MA ](https://www.sparkfun.com/products/19895) | adafruit-circuitpython-lsm6ds |
-| [Adafruit](https://www.adafruit.com) | [LSM9DS1](https://www.adafruit.com/product/4634) | adafruit-circuitpython-lsm9ds1 | 
-| [Adafruit](https://www.adafruit.com) | [BNO055](https://www.adafruit.com/product/4646) | adafruit-circuitpython-bno055(*2) | 
-| [Adafruit](https://www.adafruit.com) | [VCNL4040](https://www.adafruit.com/product/4161) | adafruit-circuitpython-vcnl4040 |
-| [ozzmaker](https://ozzmaker.com) | [Berry GPS IMU v4](https://ozzmaker.com/product/berrygps-imu/) | adafruit-circuitpython-lsm6ds adafruit-circuitpython-lis3mdl |
-| [GPS PIE](https://gps-pie.com/) | [GPS PIE](https://gps-pie.com/) | adafruit-circuitpython-bno055(*2) |
-| [waveshare](https://www.waveshare.com/) | [Environment Sensor HAT](https://www.waveshare.com/environment-sensor-hat.htm) | adafruit-circuitpython-bme280 adafruit-circuitpython-icm20x adafruit-circuitpython-tsl2591 adafruit-circuitpython-ltr390 adafruit-circuitpython-sgp40 |
+| Manufacturer                                     | Sensor                                                                         | additional pip package                                                                                                                                |
+| :----------------------------------------------- | :----------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Pimoroni](https://shop.pimoroni.com)            | [Enviro pHAT](https://shop.pimoroni.com/products/enviro-phat)                  | None                                                                                                                                                  |
+| [Adafruit](https://www.adafruit.com)             | [BMP280](https://www.adafruit.com/product/2651)                                | None                                                                                                                                                  |
+| [Adafruit](https://www.adafruit.com)             | [BMP390](https://www.adafruit.com/product/4816)                                | None                                                                                                                                                  |
+| [Sparkfun](https://www.sparkfun.com/)            | [BMP581](https://www.sparkfun.com/products/20170)                              | None                                                                                                                                                  |
+| [Adafruit](https://www.adafruit.com)             | [LPS33HW](https://www.adafruit.com/product/4414)                               | adafruit-circuitpython-lps35hw                                                                                                                        |
+| [Strawberry Linux](https://strawberry-linux.com) | [LPS33HW](https://strawberry-linux.com/catalog/items?code=12133)               | None                                                                                                                                                  |
+| [DFRobot](https://www.dfrobot.com)               | [BMX160+BMP388](https://www.dfrobot.com/product-1928.html)                     | BMX160(\*1)                                                                                                                                           |
+| [Adafruit](https://www.adafruit.com)             | [LSM6DS33 + LIS3MDL](https://www.adafruit.com/product/4485)                    | adafruit-circuitpython-lsm6ds adafruit-circuitpython-lis3mdl                                                                                          |
+| [Sparkfun](https://www.sparkfun.com/)            | [ISM330DHCX + MMC5983MA ](https://www.sparkfun.com/products/19895)             | adafruit-circuitpython-lsm6ds                                                                                                                         |
+| [Adafruit](https://www.adafruit.com)             | [LSM9DS1](https://www.adafruit.com/product/4634)                               | adafruit-circuitpython-lsm9ds1                                                                                                                        |
+| [Adafruit](https://www.adafruit.com)             | [BNO055](https://www.adafruit.com/product/4646)                                | adafruit-circuitpython-bno055(\*2)                                                                                                                    |
+| [Adafruit](https://www.adafruit.com)             | [VCNL4040](https://www.adafruit.com/product/4161)                              | adafruit-circuitpython-vcnl4040                                                                                                                       |
+| [ozzmaker](https://ozzmaker.com)                 | [Berry GPS IMU v4](https://ozzmaker.com/product/berrygps-imu/)                 | adafruit-circuitpython-lsm6ds adafruit-circuitpython-lis3mdl                                                                                          |
+| [GPS PIE](https://gps-pie.com/)                  | [GPS PIE](https://gps-pie.com/)                                                | adafruit-circuitpython-bno055(\*2)                                                                                                                    |
+| [waveshare](https://www.waveshare.com/)          | [Environment Sensor HAT](https://www.waveshare.com/environment-sensor-hat.htm) | adafruit-circuitpython-bme280 adafruit-circuitpython-icm20x adafruit-circuitpython-tsl2591 adafruit-circuitpython-ltr390 adafruit-circuitpython-sgp40 |
 
-*1 Install manually https://github.com/spacecraft-design-lab-2019/CircuitPython_BMX160
+\*1 Install manually https://github.com/spacecraft-design-lab-2019/CircuitPython_BMX160
 
-*2 You must enable i2c slowdown. Follow [the adafruit guide](https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/i2c-clock-stretching).
-
+\*2 You must enable i2c slowdown. Follow [the adafruit guide](https://learn.adafruit.com/circuitpython-on-raspberrypi-linux/i2c-clock-stretching).
 
 If you want to get a more accurate direction with the geomagnetic sensor, install a package that corrects the geomagnetic declination.
 
@@ -207,7 +203,6 @@ $ sudo apt install python3-buttonshim
 #### PiJuice HAT
 
 Follow [official setup guide](https://github.com/PiSupply/PiJuice/tree/master/Software) of PiSupply/PiJuice
-
 
 # Quick Start
 
@@ -243,7 +238,6 @@ $ QT_QPA_PLATFORM=offscreen python3 pizero_bikecomputer.py
 
 see [hardware_installation_pitft.md](./hardware_installation_pitft.md#run-on-console)
 
-
 ### Run as a service
 
 If you use displays in console environment not X Window, install auto-run service and shutdown service.
@@ -275,7 +269,6 @@ The output of the log file will be in "/home/pi/pizero_bikecomputer/log/debug.tx
 $ sudo systemctl start pizero_bikecomputer.service
 ```
 
-
 # Usage
 
 ## Button
@@ -284,15 +277,15 @@ $ sudo systemctl start pizero_bikecomputer.service
 
 <img width="400" alt="screen01" src="https://user-images.githubusercontent.com/12926652/206077256-f8bda5e5-e4a3-4c39-a7ff-ea343067756c.png">
 
-The buttons at the bottom of the screen are assigned the following functions from left to right. 
+The buttons at the bottom of the screen are assigned the following functions from left to right.
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| Left (<) | Screen switching(Back) | None |
-| LAP | Lap | Reset |
-| MENU | Menu | None |
-| Start/Stop  | Start/Stop | Quit the program |
-| Right (>) | Screen switching(Forward) | None |
+| Button     | Short press               | Long press       |
+| :--------- | :------------------------ | :--------------- |
+| Left (<)   | Screen switching(Back)    | None             |
+| LAP        | Lap                       | Reset            |
+| MENU       | Menu                      | None             |
+| Start/Stop | Start/Stop                | Quit the program |
+| Right (>)  | Screen switching(Forward) | None             |
 
 ### Hardware button
 
@@ -312,68 +305,68 @@ see [hardware_installation_pitft.md](./hardware_installation_pitft.md#hardware-b
 From left to right, the button assignments are as follows.
 
 | Button | Short press | Long press |
-|:-|:-|:-|
-| A | Left (<) | None |
-| B | Lap | Reset |
-| C | Screenshot | None |
-| D | Start/Stop | None |
-| E | Right (>) | Menu |
+| :----- | :---------- | :--------- |
+| A      | Left (<)    | None       |
+| B      | Lap         | Reset      |
+| C      | Screenshot  | None       |
+| D      | Start/Stop  | None       |
+| E      | Right (>)   | Menu       |
 
 #### Map
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| A | Left (<) | None |
-| B | Zoom out | Reset |
-| C | Change button mode(*1) | None |
-| D | Zoom in | None |
-| E | Right (>) | Menu |
+| Button | Short press             | Long press |
+| :----- | :---------------------- | :--------- |
+| A      | Left (<)                | None       |
+| B      | Zoom out                | Reset      |
+| C      | Change button mode(\*1) | None       |
+| D      | Zoom in                 | None       |
+| E      | Right (>)               | Menu       |
 
 Another button mode
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| A | Move left | None |
-| B | Move down | Zoom out |
-| C | Restore button mode | Change move amount |
-| D | Move up | Zoom in |
-| E | Move right | Search route(*) |
+| Button | Short press         | Long press         |
+| :----- | :------------------ | :----------------- |
+| A      | Move left           | None               |
+| B      | Move down           | Zoom out           |
+| C      | Restore button mode | Change move amount |
+| D      | Move up             | Zoom in            |
+| E      | Move right          | Search route(\*)   |
 
-(*)Search route by Google Directions API. Set your API key in setting.conf.
+(\*)Search route by Google Directions API. Set your API key in setting.conf.
 
 #### Course Profile
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| A | Left (<) | None |
-| B | Zoom out | None |
-| C | Restore button mode | None |
-| D | Zoom in | None |
-| E | Right (>) | None |
+| Button | Short press         | Long press |
+| :----- | :------------------ | :--------- |
+| A      | Left (<)            | None       |
+| B      | Zoom out            | None       |
+| C      | Restore button mode | None       |
+| D      | Zoom in             | None       |
+| E      | Right (>)           | None       |
 
 Another button mode
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| A | Move left | None |
-| B | Zoom out | None |
-| C | Restore button mode | None |
-| D | Zoom in | None |
-| E | Move right | None |
+| Button | Short press         | Long press |
+| :----- | :------------------ | :--------- |
+| A      | Move left           | None       |
+| B      | Zoom out            | None       |
+| C      | Restore button mode | None       |
+| D      | Zoom in             | None       |
+| E      | Move right          | None       |
 
 #### Menu
 
 In the menu, the button assignments are changed.
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| A | Back | None |
-| B | Brightness control(*) | None |
-| C | Enter | None |
-| D | Select items (Back) | None |
-| E | Select items (Forward) | None |
+| Button | Short press            | Long press |
+| :----- | :--------------------- | :--------- |
+| A      | Back                   | None       |
+| B      | Brightness control(\*) | None       |
+| C      | Enter                  | None       |
+| D      | Select items (Back)    | None       |
+| E      | Select items (Forward) | None       |
 
-(*) If you use the MIP Reflective color LCD with backlight model.
+(\*) If you use the MIP Reflective color LCD with backlight model.
 
 ### Garmin Edge Remote (ANT+)
 
@@ -381,61 +374,61 @@ In the menu, the button assignments are changed.
 
 The button assignments are as follows.
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| PAGE | Left (<) | Right (>) |
-| CUSTOM | Change button mode | Menu |
-| LAP | Lap | None |
+| Button | Short press        | Long press |
+| :----- | :----------------- | :--------- |
+| PAGE   | Left (<)           | Right (>)  |
+| CUSTOM | Change button mode | Menu       |
+| LAP    | Lap                | None       |
 
 Another button mode
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| PAGE | ANT+ Light ON/OFF | Brightness control |
-| CUSTOM | Restore button mode | None |
-| LAP | Start/Stop | None |
+| Button | Short press         | Long press         |
+| :----- | :------------------ | :----------------- |
+| PAGE   | ANT+ Light ON/OFF   | Brightness control |
+| CUSTOM | Restore button mode | None               |
+| LAP    | Start/Stop          | None               |
 
 #### Map
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| PAGE | Left (<-) | Right (->) |
-| CUSTOM | Change button mode | Zoom out |
-| LAP | Zoom in | None |
+| Button | Short press        | Long press |
+| :----- | :----------------- | :--------- |
+| PAGE   | Left (<-)          | Right (->) |
+| CUSTOM | Change button mode | Zoom out   |
+| LAP    | Zoom in            | None       |
 
 Another button mode
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| PAGE | None | None  |
-| CUSTOM | Restore button mode| Zoom out |
-| LAP | Zoom in | None |
+| Button | Short press         | Long press |
+| :----- | :------------------ | :--------- |
+| PAGE   | None                | None       |
+| CUSTOM | Restore button mode | Zoom out   |
+| LAP    | Zoom in             | None       |
 
 #### Course Profile
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| PAGE | Left (<-) | Right (->) |
-| CUSTOM | Change button mode | Zoom out |
-| LAP | Zoom in | None |
+| Button | Short press        | Long press |
+| :----- | :----------------- | :--------- |
+| PAGE   | Left (<-)          | Right (->) |
+| CUSTOM | Change button mode | Zoom out   |
+| LAP    | Zoom in            | None       |
 
 Another button mode
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| PAGE | None | None  |
-| CUSTOM | Restore button mode| Move left |
-| LAP | Move right | None |
+| Button | Short press         | Long press |
+| :----- | :------------------ | :--------- |
+| PAGE   | None                | None       |
+| CUSTOM | Restore button mode | Move left  |
+| LAP    | Move right          | None       |
 
 #### Menu
 
 In the menu, the button assignments are changed.
 
-| Button | Short press | Long press |
-|:-|:-|:-|
-| PAGE | Select items (Forward) | None |
-| CUSTOM | Select items (Back) | None |
-| LAP | Enter | None |
+| Button | Short press            | Long press |
+| :----- | :--------------------- | :--------- |
+| PAGE   | Select items (Forward) | None       |
+| CUSTOM | Select items (Back)    | None       |
+| LAP    | Enter                  | None       |
 
 ## Map
 
@@ -458,6 +451,7 @@ Right side
 - "right"
 
 ## Course profile
+
 <img width="400" alt="map-02" src="https://user-images.githubusercontent.com/12926652/206341086-7935cfbd-8ed3-4068-9f2b-93f676a8932a.png">
 
 Left side
@@ -481,7 +475,7 @@ Right side
 <img width="400" alt="menu-02-sensors" src="https://user-images.githubusercontent.com/12926652/206076191-4b8a4084-64a0-443b-a434-f6c6b4d51e2a.png">
 
 - ANT+ Sensors
-  - Pairing with ANT+ sensors. 
+  - Pairing with ANT+ sensors.
   - You need to install the ANT+ library and to set [ANT section](#ant-section) of setting.conf with `status = True`.
   - The pairing setting is saved in setting.conf when a sensor is connected, so it will be automatically connected next time you start the program.
 - ANT+ MultiScan
@@ -510,9 +504,8 @@ Right side
   - If properly paired, Android Google Maps Directions route search results can be sent with 'Share Directions' > 'Bluetooth' > (your Raspberry Pi).
     - <img width="320" alt="mapstogpx-01" src="https://github.com/hishizuka/pizero_bikecomputer/assets/12926652/928a8ed5-82e7-4ba2-afc7-6b68150d9043"> <img width="320" alt="mapstogpx-02" src="https://github.com/hishizuka/pizero_bikecomputer/assets/12926652/d6fbfb22-5c93-47e5-920f-8ef4fc9c02de">
 
-
 ### Connectivity
- 
+
 <img width="400" alt="livetrack-01" src="https://github.com/hishizuka/pizero_bikecomputer/assets/12926652/9f9660fd-eca4-4b97-a60a-d2ff890bf3f0">
 
 - Auto BT Tethering
@@ -525,13 +518,12 @@ Right side
   - Enable real-time data upload to the [ThingsBoard](https://thingsboard.io) dashboard.
   - `tb-mqtt-client` package, which can be installed with the `pip3` command, is required.
   - Also, thingsboard device access token is required in [THINGSBOARD_API](#thingsboard_api-section) of setting.conf.
-  - You will also need to upload and set up a dashboard.　For more details of Thingboard setup, see [thingsboard_setup.md](./thingsboard_setup.md).
-
+  - You will also need to upload and set up a dashboard.　 For more details of Thingboard setup, see [thingsboard_setup.md](./thingsboard_setup.md).
 
 ### Upload Activity
 
 Uploads the most recent activity record file(.fit) created by the reset operation after the power is turned on.
- 
+
 <img width="400" alt="menu-04-upload_activity" src="https://user-images.githubusercontent.com/12926652/206076198-55803175-ef4c-4f9b-9408-b44dbe98b1b3.png">
 
 - Strava
@@ -565,7 +557,7 @@ RainViewer
 
 気象庁降水ナウキャスト(Japan)
 
-<img src ="https://user-images.githubusercontent.com/12926652/205563333-549cf4dc-abbd-4392-9233-b8391687e0bc.png" width=400/> 
+<img src ="https://user-images.githubusercontent.com/12926652/205563333-549cf4dc-abbd-4392-9233-b8391687e0bc.png" width=400/>
 
 #### Wind map
 
@@ -582,7 +574,6 @@ If ANT+ powermeter is available, set both parameters are used in W'balance (%). 
 ### System
 
 <img width="400" alt="menu-08-system" src="https://github.com/hishizuka/pizero_bikecomputer/assets/12926652/402692a5-1612-4bf3-a645-a84ba91b766b">
-
 
 - Network
   - See below.
@@ -669,7 +660,7 @@ Set the value before starting the program. If the value is set during running, i
 map.yaml entry
 
   sample_mbtile:
-    url: 
+    url:
     attribution: some attribution.
     use_mbtiles: true
 ```
@@ -685,6 +676,7 @@ map.yaml entry
 If ANT+ power meter is available, set `cp` as CP and `w_prime` as W prime balance.
 
 #### SENSOR_IMU section
+
 In modules/sensor_i2c.py, use the change_axis method to change the axis direction of the IMU (accelerometer/magnetometer/gyroscope) according to its mounting direction.
 The settings are common, so if you use individual sensors, make sure they are all pointing in the same direction.
 
@@ -709,6 +701,7 @@ Axis conversion is performed with the following variables.
 #### DISPLAY_PARAM section
 
 (experimental)
+
 - `spi_clock`: specify SPI clock of the following displays.
   - `MIP`: MIP color reflective LCD module 2.7 inch.
   - `MIP_Sharp`: SHARP Memory Display Breakout
@@ -747,7 +740,6 @@ If you want to search for a route on a map, set your `token` of the Google Direc
 #### THINGSBOARD_API section
 
 If you want to use ThingsBoard dashboard, set your `token` of the Thingboard device access token.
-
 
 ### state.pickle
 
@@ -816,7 +808,6 @@ To download the map in advance, run the program manually with the --demo option.
 $ python3 pizero_bikecomputer.py --demo
 ```
 
-Press the left button to move to the map screen and leave it for a while. The current position will move along the course and download the required area of the map. 
-
+Press the left button to move to the map screen and leave it for a while. The current position will move along the course and download the required area of the map.
 
 [Back to README.md](../README.md)

--- a/doc/software_installation.md
+++ b/doc/software_installation.md
@@ -137,6 +137,12 @@ $ sudo pip3 install st7789
 
 see [hardware_installation_pitft.md](./hardware_installation_pitft.md#display)
 
+#### ST7789_Breakout Display
+
+```
+$ sudo pip3 install adafruit_rgb_display
+```
+
 #### E-ink Displays
 
 You can use python3-pyqt5 package too.

--- a/layouts/layout-cycling.yaml
+++ b/layouts/layout-cycling.yaml
@@ -9,6 +9,15 @@ MAIN:
     Dist.: [2, 0]
     Work: [2, 1]
     Ascent: [2, 2]
+  LAYOUT_VERTICAL:
+    Power: [0, 0]
+    HR: [0, 1]
+    Speed: [1, 0]
+    Cad.: [1, 1]
+    Timer: [2, 0]
+    Dist.: [2, 1]
+    Work: [3, 0]
+    Ascent: [3, 1]
 
 GPS:
   STATUS: true

--- a/layouts/layout-cycling.yaml
+++ b/layouts/layout-cycling.yaml
@@ -33,7 +33,7 @@ GPS:
     VDOP: [2, 2]
     Heading(GPS): [3, 0]
     Heading: [3, 1]
-    Course Dist.: [3,2]
+    Course Dist.: [3, 2]
 
 I2C:
   STATUS: true
@@ -55,26 +55,26 @@ ALTITUDE_GRAPH:
 
 ACC_GRAPH:
   STATUS: true
-    
+
 ANT+_raw:
   STATUS: true
   LAYOUT:
-    Speed(ANT+): [0,0]
-    Speed(GPS): [0,1]
-    Speed17(ANT+): [0,2]
-    Power17(ANT+): [0,3]
-    Dist.(ANT+): [1,0]
-    Dist.(GPS): [1,1]
-    Dist.17(ANT+): [1,2]
-    Work17(ANT+): [1,3]
-    Power16(ANT+): [2,0]
-    Work16(ANT+): [2,1]
-    Power L(ANT+): [2,2]
-    Power18(ANT+): [2,3]
-    Torque Ef.(ANT+): [3,0]
-    Pedal Sm.(ANT+): [3,1]
-    Balance(ANT+): [3,2]
-    Work18(ANT+): [3,3]
+    Speed(ANT+): [0, 0]
+    Speed(GPS): [0, 1]
+    Speed17(ANT+): [0, 2]
+    Power17(ANT+): [0, 3]
+    Dist.(ANT+): [1, 0]
+    Dist.(GPS): [1, 1]
+    Dist.17(ANT+): [1, 2]
+    Work17(ANT+): [1, 3]
+    Power16(ANT+): [2, 0]
+    Work16(ANT+): [2, 1]
+    Power L(ANT+): [2, 2]
+    Power18(ANT+): [2, 3]
+    Torque Ef.(ANT+): [3, 0]
+    Pedal Sm.(ANT+): [3, 1]
+    Balance(ANT+): [3, 2]
+    Work18(ANT+): [3, 3]
 
 LAP_STAT-1:
   STATUS: false
@@ -127,4 +127,3 @@ SIMPLE_MAP:
 
 CUESHEET:
   STATUS: false
-

--- a/modules/config.py
+++ b/modules/config.py
@@ -223,6 +223,8 @@ class Config:
         "SPI_CLOCK": 2000000,
     }
 
+    G_DISPLAY_ORIENTATION = "horizontal"
+
     # auto backlight
     G_USE_AUTO_BACKLIGHT = True
     G_AUTO_BACKLIGHT_CUTOFF = 30

--- a/modules/display/display_core.py
+++ b/modules/display/display_core.py
@@ -20,6 +20,7 @@ SUPPORTED_DISPLAYS = {
     "Pirate_Audio": None,
     "Pirate_Audio_old": None,
     "Display_HAT_Mini": (320, 240),
+    "ST7789_Breakout": (320, 240),
 }
 
 
@@ -164,5 +165,11 @@ def init_display(config):
                 display = ST7789Display(config)
             elif config.G_DISPLAY == "Display_HAT_Mini":
                 display = ST7789Display(config, SUPPORTED_DISPLAYS[config.G_DISPLAY])
+    elif config.G_DISPLAY == "ST7789_Breakout":
+        from .st7789_breakout_display import _SENSOR_DISPLAY, ST7789BreakoutDisplay
 
+        if _SENSOR_DISPLAY:
+            display = ST7789BreakoutDisplay(
+                config, SUPPORTED_DISPLAYS[config.G_DISPLAY]
+            )
     return display

--- a/modules/display/display_core.py
+++ b/modules/display/display_core.py
@@ -48,9 +48,7 @@ class Display:
 
     @property
     def resolution(self):
-        attr = getattr(self, "size", DEFAULT_RESOLUTION)
-        # NOTE: if display orientation is not horizontal, switch width and height
-        return attr if self.config.G_DISPLAY_ORIENTATION == "horizontal" else attr[::-1]
+        return getattr(self, "size", DEFAULT_RESOLUTION)
 
     def start_coroutine(self):
         pass

--- a/modules/display/display_core.py
+++ b/modules/display/display_core.py
@@ -1,6 +1,7 @@
 import os
 
 from logger import app_logger
+from modules.config import Config
 
 DEFAULT_RESOLUTION = (400, 240)
 
@@ -34,7 +35,7 @@ class Display:
     brightness_index = 0
     brightness_table = None
 
-    def __init__(self, config):
+    def __init__(self, config: Config):
         self.config = config
 
         if self.has_auto_brightness:
@@ -47,7 +48,9 @@ class Display:
 
     @property
     def resolution(self):
-        return getattr(self, "size", DEFAULT_RESOLUTION)
+        attr = getattr(self, "size", DEFAULT_RESOLUTION)
+        # NOTE: if display orientation is not horizontal, switch width and height
+        return attr if self.config.G_DISPLAY_ORIENTATION == "horizontal" else attr[::-1]
 
     def start_coroutine(self):
         pass

--- a/modules/display/st7789_breakout_display.py
+++ b/modules/display/st7789_breakout_display.py
@@ -1,0 +1,104 @@
+import digitalio
+import board
+from PIL import Image, ImageDraw
+from logger import app_logger
+import numpy as np
+
+
+from modules.display.display_core import Display
+
+_SENSOR_DISPLAY = False
+try:
+    from adafruit_rgb_display import st7789
+
+    _SENSOR_DISPLAY = True
+except ImportError:
+    pass
+
+app_logger.info(f"ST7789 Breakout DISPLAY: {_SENSOR_DISPLAY}")
+
+
+# Configuration for CS and DC pins
+cs_pin = digitalio.DigitalInOut(board.CE0)
+dc_pin = digitalio.DigitalInOut(board.D9)
+reset_pin = digitalio.DigitalInOut(board.D24)
+
+# Config for display baudrate
+BAUDRATE = 120 * 1000 * 1000
+
+
+class ST7789BreakoutDisplay(Display):
+    st7789 = None
+    rotation = 0
+    blank_buffer = None
+    blank_draw = None
+    # backlight = None
+    pi = None
+
+    has_auto_brightness = False
+    has_color = True
+    # Actually has touch, but has to be implemented
+    has_touch = False
+    send = True
+
+    backlight_pin = digitalio.DigitalInOut(board.D13)
+    backlight_pin.direction = digitalio.Direction.OUTPUT
+
+    size = (320, 240)
+
+    def __init__(self, config, size=None):
+        super().__init__(config)
+
+        is_horizontal = config.G_DISPLAY_ORIENTATION == "horizontal"
+
+        if size is not None:
+            self.size = size if is_horizontal else size[::-1]
+            pass
+
+        spi = board.SPI()
+
+        res = self.resolution
+
+        if is_horizontal:
+            res = res[::-1]
+            self.rotation = 90
+
+        self.st7789 = st7789.ST7789(
+            spi,
+            rotation=self.rotation,
+            width=res[0],
+            height=res[1],
+            x_offset=0,
+            y_offset=0,
+            cs=cs_pin,
+            dc=dc_pin,
+            rst=reset_pin,
+            baudrate=BAUDRATE,
+        )
+
+        self.set_brightness(1)
+
+        self.blank_buffer = Image.new("RGB", self.resolution)
+        self.blank_draw = ImageDraw.Draw(self.blank_buffer)
+        self.blank_draw.rectangle((0, 0, *self.resolution), (0, 0, 0))
+        self.clear()
+
+    def quit(self):
+        self.clear()
+        self.set_brightness(0)
+
+    def clear(self):
+        self.st7789.image(self.blank_buffer)
+
+    def update(self, im_array, direct_update=False):
+        im_array = 255 - im_array
+        img = Image.fromarray(im_array, "RGB")
+        self.st7789.image(img)
+
+    def set_brightness(self, b):
+        # 0 will be False, everything greater than 0 will be True
+        b = bool(b)
+        if b == self.backlight_pin.value:
+            return
+
+        self.backlight_pin.value = b

--- a/modules/gui_pyqt.py
+++ b/modules/gui_pyqt.py
@@ -344,7 +344,15 @@ class GUI_PyQt(QtCore.QObject):
             for k, v in self.gui_config.layout.items():
                 if not v["STATUS"]:
                     continue
-                if "LAYOUT" in v:
+                if "LAYOUT_VERTICAL" in v and self.config.G_DISPLAY_ORIENTATION == "vertical":
+                    self.main_page.addWidget(
+                        ValuesWidget(
+                            self.main_page,
+                            self.config,
+                            v["LAYOUT_VERTICAL"],
+                        )
+                    )
+                elif "LAYOUT" in v:
                     self.main_page.addWidget(
                         ValuesWidget(
                             self.main_page,

--- a/modules/gui_pyqt.py
+++ b/modules/gui_pyqt.py
@@ -7,6 +7,7 @@ import asyncio
 import numpy as np
 
 from logger import app_logger
+from modules.config import Config
 from modules.gui_config import GUI_Config
 from modules._pyqt import (
     QT_ALIGN_BOTTOM,
@@ -48,14 +49,9 @@ class SplashScreen(QtWidgets.QWidget):
 
 
 class BootStatus(QtWidgets.QLabel):
-    STYLES = """
-      color: white;
-      font-size: 20px;
-    """
-
-    def __init__(self, *__args):
-        super().__init__(*__args)
-        self.setStyleSheet(self.STYLES)
+    def __init__(self, font_size: float):
+        super().__init__()
+        self.setStyleSheet(f"color: white; font-size: {font_size}px;")
         self.setAlignment(QT_ALIGN_CENTER)
 
 
@@ -133,7 +129,7 @@ class GUI_PyQt(QtCore.QObject):
     def logger(self):
         return self.config.logger
 
-    def __init__(self, config):
+    def __init__(self, config: Config):
         super().__init__()
 
         self.config = config
@@ -175,7 +171,7 @@ class GUI_PyQt(QtCore.QObject):
         splash_layout.setContentsMargins(0, 0, 0, 0)
         splash_layout.setSpacing(0)
 
-        boot_status = BootStatus()
+        boot_status = BootStatus(20 if self.config.G_DISPLAY_ORIENTATION == "horizontal" else 15)
         self.signal_boot_status.connect(boot_status.setText)
         splash_layout.addWidget(boot_status)
 

--- a/modules/helper/setting.py
+++ b/modules/helper/setting.py
@@ -44,6 +44,8 @@ class Setting:
                 self.config.G_LANG = c["LANG"].upper()
             if "FONT_FILE" in c:
                 self.config.G_FONT_FILE = c["FONT_FILE"]
+            if "DISPLAY_ORIENTATION" in c:
+                self.config.G_DISPLAY_ORIENTATION = c["DISPLAY_ORIENTATION"]
 
         if "MAP_AND_DATA" in self.config_parser:
             c = self.config_parser["MAP_AND_DATA"]
@@ -228,6 +230,7 @@ class Setting:
         c["AUTO_BACKLIGHT_CUTOFF"] = str(int(self.config.G_AUTO_BACKLIGHT_CUTOFF))
         c["LANG"] = self.config.G_LANG
         c["FONT_FILE"] = self.config.G_FONT_FILE
+        c["DISPLAY_ORIENTATION"] = self.config.G_DISPLAY_ORIENTATION
 
         self.config_parser["MAP_AND_DATA"] = {}
         c = self.config_parser["MAP_AND_DATA"]

--- a/modules/pyqt/components/box_buttons.py
+++ b/modules/pyqt/components/box_buttons.py
@@ -19,10 +19,10 @@ class LapButton(QtWidgets.QPushButton):
       }
     """
 
-    def __init__(self, *args):
+    def __init__(self, button_width, *args):
         super().__init__(LapIcon(), "", *args)
         self.setStyleSheet(self.STYLES)
-        self.setFixedSize(50, 30)
+        self.setFixedSize(button_width, 30)
         # long press
         self.setAutoRepeat(True)
         self.setAutoRepeatDelay(1000)
@@ -45,22 +45,22 @@ class MenuButton(QtWidgets.QPushButton):
       }
     """
 
-    def __init__(self, *args):
+    def __init__(self, button_width, *args):
         super().__init__(MenuIcon(), "", *args)
-        self.setFixedSize(50, 30)
+        self.setFixedSize(button_width, 30)
         self.setStyleSheet(self.STYLES)
 
 
 class ScrollNextButton(NaviButton):
-    def __init__(self, *args):
+    def __init__(self, button_width, *args):
         super().__init__(ForwardIcon(), "", *args)
-        self.setFixedSize(60, 30)
+        self.setFixedSize(button_width + 10, 30)
 
 
 class ScrollPrevButton(NaviButton):
-    def __init__(self, *args):
+    def __init__(self, button_width, *args):
         super().__init__(BackIcon(), "", *args)
-        self.setFixedSize(60, 30)
+        self.setFixedSize(button_width + 10, 30)
 
 
 class StartButton(QtWidgets.QPushButton):
@@ -79,10 +79,10 @@ class StartButton(QtWidgets.QPushButton):
       }
     """
 
-    def __init__(self, *args):
+    def __init__(self, button_width, *args):
         super().__init__(NextIcon(), "", *args)
         self.setStyleSheet(self.STYLES)
-        self.setFixedSize(50, 30)
+        self.setFixedSize(button_width, 30)
         # long press
         self.setAutoRepeat(True)
         self.setAutoRepeatDelay(1000)

--- a/modules/pyqt/components/topbar.py
+++ b/modules/pyqt/components/topbar.py
@@ -18,14 +18,10 @@ class TopBar:
 
 
 class TopBarLabel(QtWidgets.QLabel):
-    STYLES = """
-      color: #FFFFFF;
-    """
-
-    def __init__(self, *__args):
+    def __init__(self, font_size, *__args):
         super().__init__(*__args)
         self.setAlignment(QT_ALIGN_CENTER)
-        self.setStyleSheet(self.STYLES)
+        self.setStyleSheet(f"color: #FFFFFF; padding-right: 42.5px; font-size: {font_size}px;")
 
 
 class TopBarBackButton(NaviButton):

--- a/modules/pyqt/graph/pyqt_value_graph.py
+++ b/modules/pyqt/graph/pyqt_value_graph.py
@@ -6,15 +6,6 @@ from modules.pyqt.pyqt_screen_widget import ScreenWidget
 
 
 class PerformanceGraphWidget(ScreenWidget):
-    item_layout = {
-        "Power": (0, 0),
-        "HR": (0, 1),
-        "W'bal(Norm)": (0, 2),
-        "LapTime": (0, 3),
-    }
-    max_height = 1
-    max_width = 3
-
     # for Power
     # brush = pg.mkBrush(color=(0,160,255,64))
     brush = pg.mkBrush(color=(0, 255, 255))
@@ -22,6 +13,8 @@ class PerformanceGraphWidget(ScreenWidget):
     pen1 = pg.mkPen(color=(255, 255, 255), width=0.01)  # transparent and thin line
     # for HR, wbal
     pen2 = pg.mkPen(color=(255, 0, 0), width=2)
+
+    plot_data_x1 = []
 
     def __init__(self, parent, config):
         self.display_item = config.G_GUI_PERFORMANCE_GRAPH_DISPLAY_ITEM
@@ -42,11 +35,30 @@ class PerformanceGraphWidget(ScreenWidget):
                 "yrange": [config.G_GUI_MIN_W_BAL, config.G_GUI_MAX_W_BAL],
             },
         }
-        self.plot_data_x1 = []
+
         for i in range(config.G_GUI_PERFORMANCE_GRAPH_DISPLAY_RANGE + 1):
             self.plot_data_x1.append(i)
 
-        super().__init__(parent, config)
+        self.is_horizontal = config.G_DISPLAY_ORIENTATION == "horizontal"
+
+        self.max_height = 1
+        self.max_width = 3 if self.is_horizontal else 1
+
+        item_layout = {
+            "Power": (0, 0),
+            "HR": (0, 1),
+            "W'bal(Norm)": (0, 2),
+            "LapTime": (0, 3),
+        }
+
+        item_layout_vertical = {
+            "Power": (0, 0),
+            "HR": (0, 1),
+            "W'bal(Norm)": (1, 0),
+            "LapTime": (1, 1),
+        }
+
+        super().__init__(parent, config, item_layout if self.is_horizontal else item_layout_vertical)
 
     def setup_ui_extra(self):
         # 1st graph: POWER
@@ -72,7 +84,10 @@ class PerformanceGraphWidget(ScreenWidget):
         # p2 on p1
         self.p1.setZValue(-100)
 
-        self.layout.addWidget(plot, 1, 0, 2, 4)
+        if self.is_horizontal:
+            self.layout.addWidget(plot, 1, 0, 2, 4)
+        else:
+            self.layout.addWidget(plot, 2, 0, 2, 2)
 
     def set_font_size(self, length):
         self.font_size = int(length / 7)

--- a/modules/pyqt/graph/pyqt_value_graph.py
+++ b/modules/pyqt/graph/pyqt_value_graph.py
@@ -142,21 +142,34 @@ class PerformanceGraphWidget(ScreenWidget):
 
 
 class AccelerationGraphWidget(ScreenWidget):
-    item_layout = {
-        "ACC_X": (0, 0),
-        "ACC_Y": (0, 1),
-        "ACC_Z": (0, 2),
-        "M_Stat": (0, 3),
-    }
-    max_height = 1
-    max_width = 3
-
     # for acc
     pen1 = pg.mkPen(color=(0, 0, 255), width=3)
     pen2 = pg.mkPen(color=(255, 0, 0), width=3)
     pen3 = pg.mkPen(color=(0, 0, 0), width=2)
 
     g_range = 0.3
+
+    def __init__(self, parent, config: Config):
+        self.is_horizontal = config.G_DISPLAY_ORIENTATION == "horizontal"
+
+        self.max_height = 1
+        self.max_width = 3 if self.is_horizontal else 1
+
+        item_layout = {
+            "ACC_X": (0, 0),
+            "ACC_Y": (0, 1),
+            "ACC_Z": (0, 2),
+            "M_Stat": (0, 3),
+        }
+
+        item_layout_vertical = {
+            "ACC_X": (0, 0),
+            "ACC_Y": (0, 1),
+            "ACC_Z": (1, 0),
+            "M_Stat": (1, 1),
+        }
+
+        super().__init__(parent, config, item_layout if self.is_horizontal else item_layout_vertical)
 
     def setup_ui_extra(self):
         plot = pg.PlotWidget()
@@ -175,7 +188,10 @@ class AccelerationGraphWidget(ScreenWidget):
         plot.setXRange(0, self.config.G_GUI_ACC_TIME_RANGE)
         plot.setMouseEnabled(x=False, y=False)
 
-        self.layout.addWidget(plot, 1, 0, 2, 4)
+        if self.is_horizontal:
+            self.layout.addWidget(plot, 1, 0, 2, 4)
+        else:
+            self.layout.addWidget(plot, 2, 0, 2, 2)
 
     def start(self):
         self.timer.start(self.config.G_REALTIME_GRAPH_INTERVAL)

--- a/modules/pyqt/graph/pyqt_value_graph.py
+++ b/modules/pyqt/graph/pyqt_value_graph.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from modules._pyqt import pg, qasync
+from modules.config import Config
 from modules.pyqt.pyqt_screen_widget import ScreenWidget
 
 
@@ -233,15 +234,6 @@ class AccelerationGraphWidget(ScreenWidget):
 
 
 class AltitudeGraphWidget(ScreenWidget):
-    item_layout = {
-        "Grade": (0, 0),
-        "Grade(spd)": (0, 1),
-        "Altitude": (0, 2),
-        "Alt.(GPS)": (0, 3),
-    }
-    max_height = 1
-    max_width = 3
-
     # for altitude_raw
     pen1 = pg.mkPen(color=(0, 0, 0), width=2)
     pen2 = pg.mkPen(color=(255, 0, 0), width=3)
@@ -251,6 +243,28 @@ class AltitudeGraphWidget(ScreenWidget):
     #     self.plot_data_x1 = []
     #     for i in range(self.config.G_GUI_PERFORMANCE_GRAPH_DISPLAY_RANGE):
     #       self.plot_data_x1.append(i)
+
+    def __init__(self, parent, config: Config):
+        self.is_horizontal = config.G_DISPLAY_ORIENTATION == "horizontal"
+
+        self.max_height = 1
+        self.max_width = 3 if self.is_horizontal else 1
+
+        item_layout = {
+            "Grade": (0, 0),
+            "Grade(spd)": (0, 1),
+            "Altitude": (0, 2),
+            "Alt.(GPS)": (0, 3),
+        }
+
+        item_layout_vertical = {
+            "Grade": (0, 0),
+            "Grade(spd)": (0, 1),
+            "Altitude": (1, 0),
+            "Alt.(GPS)": (1, 1),
+        }
+
+        super().__init__(parent, config, item_layout if self.is_horizontal else item_layout_vertical)
 
     def setup_ui_extra(self):
         plot = pg.PlotWidget()
@@ -268,7 +282,10 @@ class AltitudeGraphWidget(ScreenWidget):
         self.y_range = 15
         self.y_shift = 0  # self.y_ra  nge * 0.25
 
-        self.layout.addWidget(plot, 1, 0, 2, 4)
+        if self.is_horizontal:
+            self.layout.addWidget(plot, 1, 0, 2, 4)
+        else:
+            self.layout.addWidget(plot, 2, 0, 2, 2)
 
     def set_font_size(self, length):
         self.font_size = int(length / 7)

--- a/modules/pyqt/menu/pyqt_adjust_widget.py
+++ b/modules/pyqt/menu/pyqt_adjust_widget.py
@@ -72,32 +72,34 @@ class AdjustWidget(MenuWidget):
     unit = ""
 
     def setup_menu(self):
+        x_max = (5 if self.config.G_DISPLAY_ORIENTATION == "horizontal" else 3)
+
         self.make_menu_layout(QtWidgets.QGridLayout)
 
         self.display = AdjustEdit("")
-        self.menu_layout.addWidget(self.display, 0, 0, 1, 5)
+        self.menu_layout.addWidget(self.display, 0, 0, 1, x_max)
 
         unitLabel = UnitLabel(self.unit)
-        self.menu_layout.addWidget(unitLabel, 0, 5)
+        self.menu_layout.addWidget(unitLabel, 0, x_max)
 
         num_buttons = {}
         for i in [1, 2, 3, 4, 5, 6, 7, 8, 9, 0]:
             num_buttons[i] = AdjustButton(str(i))
             num_buttons[i].clicked.connect(self.digit_clicked)
             if i == 0:
-                self.menu_layout.addWidget(num_buttons[i], 2, 4)
+                self.menu_layout.addWidget(num_buttons[i], (2 if self.config.G_DISPLAY_ORIENTATION == "horizontal" else 3), (4 if self.config.G_DISPLAY_ORIENTATION == "horizontal" else 3))
             else:
                 self.menu_layout.addWidget(
-                    num_buttons[i], 1 + (i - 1) // 5, (i - 1) % 5
+                    num_buttons[i], 1 + (i - 1) // x_max, (i - 1) % x_max
                 )
 
         clear_button = AdjustButton("Del")
         clear_button.clicked.connect(self.clear)
-        self.menu_layout.addWidget(clear_button, 1, 5)
+        self.menu_layout.addWidget(clear_button, 1, x_max)
 
         set_button = AdjustButton("Set")
         set_button.clicked.connect(self.set_value)
-        self.menu_layout.addWidget(set_button, 2, 5)
+        self.menu_layout.addWidget(set_button, 2, x_max)
 
         if not self.config.display.has_touch:
             self.focus_widget = num_buttons[1]

--- a/modules/pyqt/menu/pyqt_adjust_widget.py
+++ b/modules/pyqt/menu/pyqt_adjust_widget.py
@@ -91,7 +91,7 @@ class AdjustWidget(MenuWidget):
                     num_buttons[i], 1 + (i - 1) // 5, (i - 1) % 5
                 )
 
-        clear_button = AdjustButton("x")
+        clear_button = AdjustButton("Del")
         clear_button.clicked.connect(self.clear)
         self.menu_layout.addWidget(clear_button, 1, 5)
 

--- a/modules/pyqt/menu/pyqt_course_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_course_menu_widget.py
@@ -9,6 +9,7 @@ from modules._pyqt import (
     QtGui,
     qasync,
 )
+from modules.config import Config
 from modules.pyqt.components import icons, topbar
 from modules.utils.network import detect_network
 from .pyqt_menu_widget import (
@@ -230,14 +231,14 @@ class CourseListWidget(ListWidget):
     async def list_local_courses(self):
         courses = self.config.get_courses()
         for c in courses:
-            course_item = CourseListItemWidget(self, self.list_type, c)
+            course_item = CourseListItemWidget(self, self.list_type, c, self.config)
             self.add_list_item(course_item)
 
     async def list_ride_with_gps(self, add=False, reset=False):
         courses = await self.config.api.get_ridewithgps_route(add, reset)
 
         for c in reversed(courses or []):
-            course_item = CourseListItemWidget(self, self.list_type, c)
+            course_item = CourseListItemWidget(self, self.list_type, c, self.config)
             self.add_list_item(course_item)
 
     def set_course(self, course_file=None):
@@ -277,7 +278,7 @@ class CourseListItemWidget(ListItemWidget):
     list_type = None
     locality_text = ", {elevation_gain:.0f}m up, {locality}, {administrative_area}"
 
-    def __init__(self, parent, list_type, list_info):
+    def __init__(self, parent, list_type, list_info, config: Config):
         self.list_type = list_type
         self.list_info = list_info.copy()
 
@@ -289,7 +290,7 @@ class CourseListItemWidget(ListItemWidget):
         else:
             detail = None
 
-        super().__init__(parent=parent, title=list_info["name"], detail=detail)
+        super().__init__(parent=parent, title=list_info["name"], detail=detail, config=config)
 
         if self.list_type == "Local Storage":
             self.enter_signal.connect(parent.set_course)

--- a/modules/pyqt/menu/pyqt_menu_button.py
+++ b/modules/pyqt/menu/pyqt_menu_button.py
@@ -57,6 +57,8 @@ class MenuButton(QtWidgets.QPushButton):
         self.config = config
         self.button_type = button_type
 
+        self.setMinimumHeight(40)
+        self.setMaximumHeight(50)
         self.setSizePolicy(
             QT_EXPANDING,
             QT_EXPANDING,
@@ -100,8 +102,9 @@ class MenuButton(QtWidgets.QPushButton):
         self.setProperty("style", None)
 
     def resizeEvent(self, event):
-        # w = self.size().width()
         h = self.size().height()
+
+        # NOTE: why x > 0 else 1? is there an undocumented edge case?
         psize = int(h / 2.5) if int(h / 2.5) > 0 else 1
 
         q = self.font()

--- a/modules/pyqt/menu/pyqt_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_menu_widget.py
@@ -216,7 +216,7 @@ class ListWidget(MenuWidget):
 
         if self.settings and self.settings.keys():
             for k in self.settings.keys():
-                item = ListItemWidget(self, k)
+                item = ListItemWidget(self, self.config, k)
                 item.enter_signal.connect(self.button_func)
                 self.add_list_item(item)
 
@@ -241,7 +241,7 @@ class ListWidget(MenuWidget):
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
-        h = int((self.height() - self.top_bar.height()) / 4)
+        h = int((self.height() - self.top_bar.height()) / (4 if self.width() > self.height() else 8))
         self.size_hint = QtCore.QSize(self.top_bar.width(), h)
         for i in range(self.list.count()):
             self.list.item(i).setSizeHint(self.size_hint)
@@ -295,7 +295,8 @@ class ListItemWidget(QtWidgets.QWidget):
             title_style = f"{title_style} {border_style}"
         return title_style, detail_style
 
-    def __init__(self, parent, title, detail=None):
+    def __init__(self, parent, config: Config, title, detail=None):
+        self.config = config
         self.title = title
         self.detail = detail
         QtWidgets.QWidget.__init__(self, parent=parent)

--- a/modules/pyqt/menu/pyqt_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_menu_widget.py
@@ -77,7 +77,7 @@ class MenuWidget(QtWidgets.QWidget):
     def add_buttons(self, buttons):
         n = len(buttons)
 
-        if n <= 4:
+        if n <= 4 or self.config.G_DISPLAY_ORIENTATION == "vertical":
             layout_type = QtWidgets.QVBoxLayout
         else:
             layout_type = QtWidgets.QGridLayout
@@ -109,6 +109,10 @@ class MenuWidget(QtWidgets.QWidget):
         if n in (1, 2, 3):
             for j in range(4 - n):
                 self.menu_layout.addWidget(MenuButton("dummy", "", self.config))
+
+        if layout_type == QtWidgets.QVBoxLayout and self.config.G_DISPLAY_ORIENTATION == "vertical" and len(self.buttons) <= 5:
+            spacer = QtWidgets.QSpacerItem(20, 40, QtWidgets.QSizePolicy.Policy.Minimum, QtWidgets.QSizePolicy.Policy.Expanding)
+            self.menu_layout.addItem(spacer)
 
         # set first focus
         if not self.config.display.has_touch:

--- a/modules/pyqt/menu/pyqt_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_menu_widget.py
@@ -8,6 +8,7 @@ from modules._pyqt import (
     QtWidgets,
     qasync,
 )
+from modules.config import Config
 from modules.pyqt.components import icons, topbar
 
 from .pyqt_menu_button import MenuButton
@@ -29,7 +30,7 @@ class MenuWidget(QtWidgets.QWidget):
     icon_x = 40
     icon_y = 32
 
-    def __init__(self, parent, page_name, config):
+    def __init__(self, parent, page_name, config: Config):
         QtWidgets.QWidget.__init__(self, parent=parent)
         self.config = config
         self.page_name = page_name
@@ -48,7 +49,7 @@ class MenuWidget(QtWidgets.QWidget):
         self.top_bar = topbar.TopBar()
 
         self.back_button = topbar.TopBarBackButton((self.icon_x, self.icon_y))
-        self.page_name_label = topbar.TopBarLabel(self.page_name)
+        self.page_name_label = topbar.TopBarLabel(20 if self.config.G_DISPLAY_ORIENTATION == "horizontal" else 15, self.page_name)
 
         self.top_bar_layout = QtWidgets.QHBoxLayout()
         self.top_bar_layout.setContentsMargins(5, 5, 5, 5)

--- a/modules/pyqt/menu/pyqt_sensor_menu_widget.py
+++ b/modules/pyqt/menu/pyqt_sensor_menu_widget.py
@@ -160,7 +160,7 @@ class ANTListWidget(ListWidget):
                 status_str = " (connected)" if status else ""
                 sensor_type = self.config.G_ANT["TYPE_NAME"][ant_type_array[0]]
                 title = f"{sensor_type} {status_str}".strip()
-                ant_item = ANTListItemWidget(self, ant_id_str, title)
+                ant_item = ANTListItemWidget(self, self.config, ant_id_str, title)
 
                 self.add_list_item(ant_item)
 
@@ -170,9 +170,9 @@ class ANTListWidget(ListWidget):
 class ANTListItemWidget(ListItemWidget):
     id = None
 
-    def __init__(self, parent, ant_id, title):
+    def __init__(self, parent, config, ant_id, title):
         self.id = ant_id
-        super().__init__(parent, title, detail=f"   ID: {ant_id}")
+        super().__init__(parent, config, title, detail=f"   ID: {ant_id}")
 
     def setup_ui(self):
         super().setup_ui()

--- a/modules/pyqt/pyqt_button_box_widget.py
+++ b/modules/pyqt/pyqt_button_box_widget.py
@@ -1,5 +1,6 @@
 from logger import app_logger
 from modules._pyqt import QtWidgets
+from modules.config import Config
 from modules.pyqt.components import box_buttons, icons
 
 
@@ -14,7 +15,7 @@ class ButtonBoxWidget(QtWidgets.QWidget):
     lap_button_count = 0
     start_button_count = 0
 
-    def __init__(self, parent, config):
+    def __init__(self, parent, config: Config):
         self.config = config
         super().__init__(parent=parent)
         self.setup_ui()
@@ -25,11 +26,13 @@ class ButtonBoxWidget(QtWidgets.QWidget):
         self.show()
         self.setAutoFillBackground(True)
 
-        self.start_button = box_buttons.StartButton()
-        self.lap_button = box_buttons.LapButton()
-        menu_button = box_buttons.MenuButton()
-        scrollnext_button = box_buttons.ScrollNextButton()
-        scrollprev_button = box_buttons.ScrollPrevButton()
+        button_width = 50 if self.config.G_DISPLAY_ORIENTATION == "horizontal" else 40
+
+        self.start_button = box_buttons.StartButton(button_width)
+        self.lap_button = box_buttons.LapButton(button_width)
+        menu_button = box_buttons.MenuButton(button_width)
+        scrollnext_button = box_buttons.ScrollNextButton(button_width)
+        scrollprev_button = box_buttons.ScrollPrevButton(button_width)
 
         self.start_button.clicked.connect(self.gui_start_and_stop_quit)
         self.lap_button.clicked.connect(self.gui_lap_reset)

--- a/modules/pyqt/pyqt_screen_widget.py
+++ b/modules/pyqt/pyqt_screen_widget.py
@@ -1,5 +1,6 @@
 from logger import app_logger
 from modules._pyqt import QT_EXPANDING, QtCore, QtWidgets, qasync
+from modules.config import Config
 
 from .pyqt_item import Item
 
@@ -13,7 +14,7 @@ class ScreenWidget(QtWidgets.QWidget):
     font_size = 12
     max_width = max_height = 0
 
-    def __init__(self, parent, config, item_layout=None):
+    def __init__(self, parent, config: Config, item_layout=None):
         self.config = config
         self.items = []
 
@@ -46,7 +47,8 @@ class ScreenWidget(QtWidgets.QWidget):
 
     def resizeEvent(self, event):
         h = self.size().height()
-        self.set_font_size(h)
+        w = self.size().width()
+        self.set_font_size(h if h < w else w)
         for i in self.items:
             i.update_font_size(self.font_size)
 
@@ -81,6 +83,9 @@ class ScreenWidget(QtWidgets.QWidget):
         pass
 
     def set_font_size(self, length):
+        if self.config.G_DISPLAY_ORIENTATION == "vertical":
+            length *= .7
+            
         # need to modify for automation and scaling
         self.font_size = int(length / 6)  # 2 rows (100px)
         if self.max_height == 2:  # 3 rows (66px)

--- a/modules/pyqt/pyqt_screen_widget.py
+++ b/modules/pyqt/pyqt_screen_widget.py
@@ -84,7 +84,7 @@ class ScreenWidget(QtWidgets.QWidget):
 
     def set_font_size(self, length):
         if self.config.G_DISPLAY_ORIENTATION == "vertical":
-            length *= .7
+            length *= .8
             
         # need to modify for automation and scaling
         self.font_size = int(length / 6)  # 2 rows (100px)


### PR DESCRIPTION
Hi!
This pull request introduces a new feature that allows users to choose between a horizontal or vertical display orientation.

### Changes Implemented:
#### Config:
- Added a new setting/config property: `G_DISPLAY_ORIENTATION`.
- Added new yaml property: `LAYOUT_VERTICAL`.
    - Using this property, you can provide one layout for each display orientation.

#### UI Adjustments:
- Modified the layout logic to dynamically adjust based on the selected orientation.

#### Refactor:
- Change the `clear_button` label from `x` to `Del`