### PR TITLE
Fix to gui_pyqt.py when reset_count_internal() and no active map widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /courses/*html*
 /fonts/*
 /.idea/
+*.iml
 /.vscode/
 /.venv/
 __pycache__/

--- a/modules/gui_pyqt.py
+++ b/modules/gui_pyqt.py
@@ -431,7 +431,8 @@ class GUI_PyQt(GUI_Qt_Base):
 
     def reset_count_internal(self):
         res = self.logger.reset_count()
-        self.map_widget.reset_track()
+        if self.map_widget is not None:
+            self.map_widget.reset_track()
         if (
             res
             and self.config.G_AUTO_UPLOAD


### PR DESCRIPTION
* When the map widget is not active an error is thrown when resetting the timer. 
* added *.iml extension to .gitignore