### PR TITLE
Add deploy script and ANT+ error handling improvements

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -576,14 +576,17 @@ class Config:
         await self.app_close_event.wait()
 
     async def delay_init(self):
+        import time
         await asyncio.sleep(0.01)
         t = Timer(auto_start=True, auto_log=True, text="delay init: {0:.3f} sec")
 
         # network
         await self.gui.set_boot_status("initialize network modules...")
+        start = time.time()
         from modules.helper.api import api
         from modules.helper.network import Network
         from modules.helper.network.wifi_manager import get_wifi_bt_status
+        print(f'[DEBUG] network imports: {time.time() - start:.2f}s')
 
         # bluetooth
         _, bt_available = get_wifi_bt_status()
@@ -596,13 +599,16 @@ class Config:
                 HAS_DBUS_FAST,
                 HAS_DBUS,
             )
+            print(f'[DEBUG] bluetooth imports: {time.time() - start:.2f}s')
 
             if HAS_DBUS_FAST:
                 self.bt_pan = BTPanDbusFast()
             elif HAS_DBUS:
                 self.bt_pan = BTPanDbus()
             if HAS_DBUS_FAST or HAS_DBUS:
+                print(f'[DEBUG] calling update_bt_pan_devices: {time.time() - start:.2f}s')
                 await self.bt_pan.update_bt_pan_devices()
+                print(f'[DEBUG] update_bt_pan_devices done: {time.time() - start:.2f}s')
 
         if self.G_AUTO_BT_TETHERING and self.bt_pan is None:
             if not self.G_IS_RASPI:
@@ -621,7 +627,10 @@ class Config:
 
         # logger, sensor
         await self.gui.set_boot_status("initialize sensor...")
+        import time
+        start = time.time()
         self.logger.delay_init()
+        print(f'[DEBUG] delay_init done: {time.time() - start:.2f}s')
 
         # GadgetBridge (has to be before gui but after sensors for proper init state of buttons)
         if self.G_IS_RASPI and bt_available:

--- a/modules/sensor/ant/ant_device.py
+++ b/modules/sensor/ant/ant_device.py
@@ -151,8 +151,8 @@ class ANT_Device:
             self.channel.open()
             if isChange:
                 self.config.G_ANT["USE"][self.name] = True
-        except:
-            pass
+        except Exception as e:
+            app_logger.debug(f"[ANT+] Failed to open channel for {self.name}: {e}")
 
     def init_after_connect(self):
         pass
@@ -173,8 +173,8 @@ class ANT_Device:
             self.channel.wait_for_event([0x07,])  # EVENT_CHANNEL_CLOSED
             if isChange:
                 self.config.G_ANT["USE"][self.name] = False
-        except:
-            pass
+        except Exception as e:
+            app_logger.debug(f"[ANT+] Error disconnecting {self.name}: {e}")
 
     def delete(self):
         self.node.delete_channel()

--- a/modules/sensor/ant/ant_device_multiscan.py
+++ b/modules/sensor/ant/ant_device_multiscan.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from . import ant_device
 from . import ant_device_power
+from modules.app_logger import app_logger
 
 
 class ANT_Device_MultiScan(ant_device.ANT_Device):
@@ -53,8 +54,8 @@ class ANT_Device_MultiScan(ant_device.ANT_Device):
             try:
                 self.channel.open_rx_scan_mode()
                 self.isUse = True
-            except:
-                pass
+            except Exception as e:
+                app_logger.debug(f"[ANT+] Error opening scan mode: {e}")
 
     def stop_scan(self):
         self.disconnect()
@@ -77,7 +78,8 @@ class ANT_Device_MultiScan(ant_device.ANT_Device):
             self.isUse = False
             self.channel.enable_extended_messages(0)
             return True
-        except:
+        except Exception as e:
+            app_logger.debug(f"[ANT+] Error disconnecting scan: {e}")
             return False
 
     def set_main_ant_device(self, device):

--- a/modules/sensor/ant/ant_device_search.py
+++ b/modules/sensor/ant/ant_device_search.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from . import ant_device
 from . import ant_device_ctrl
+from modules.app_logger import app_logger
 
 
 class ANT_Device_Search(ant_device.ANT_Device):
@@ -121,8 +122,8 @@ class ANT_Device_Search(ant_device.ANT_Device):
                     try:
                         ctrl.send_data = False
                         ctrl.channel.on_acknowledge_data = ctrl.on_data
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        app_logger.debug(f"[ANT+] Error restoring callback: {e}")
 
                     ctrl.disconnect(isCheck=False, isChange=False)
                     if self._ctrl_searcher_owned:

--- a/modules/sensor/sensor_ant.py
+++ b/modules/sensor/sensor_ant.py
@@ -19,6 +19,31 @@ from .ant import ant_device_search
 # ANT+
 _SENSOR_ANT = False
 
+_ANT_DEVICE_ID_VENDOR = 0x0fcf
+_ANT_DEVICE_ID_PRODUCT = 0x1008
+
+def _wake_up_ant_stick():
+    try:
+        import usb.core
+        import usb.util
+        dev = usb.core.find(idVendor=_ANT_DEVICE_ID_VENDOR, idProduct=_ANT_DEVICE_ID_PRODUCT)
+        if dev:
+            try:
+                dev.set_configuration()
+                cfg = dev.get_active_configuration()
+                intf = cfg[(0, 0)]
+                ep_out = usb.util.find_descriptor(
+                    intf,
+                    custom_match=lambda e: usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_OUT
+                )
+                if ep_out:
+                    ep_out.write(b'', 1000)
+                    app_logger.debug("[ANT+] ANT stick wake-up sent")
+            except Exception as e:
+                app_logger.debug(f"[ANT+] Could not wake up ANT stick (may already be in use): {e}")
+    except Exception as e:
+        app_logger.debug(f"[ANT+] Could not find ANT stick: {e}")
+
 try:
     from ant.easy.node import Node
     from ant.base.driver import find_driver, DriverNotFound
@@ -48,6 +73,7 @@ class SensorANT(Sensor):
             self.config.G_ANT["STATUS"] = False
 
         if self.config.G_ANT["STATUS"]:
+            _wake_up_ant_stick()
             self.node = Node()
             self.node.set_network_key(self.NETWORK_NUM, self.NETWORK_KEY)
 
@@ -110,7 +136,18 @@ class SensorANT(Sensor):
 
     async def start(self):
         if self.config.G_ANT["STATUS"]:
-            await asyncio.get_running_loop().run_in_executor(None, self.node.start)
+            try:
+                await asyncio.get_running_loop().run_in_executor(None, self.node.start)
+            except Exception as e:
+                import traceback
+                app_logger.error("[ANT+] Failed to start ANT+ node")
+                app_logger.error(f"[ANT+] Error: {e}")
+                app_logger.error("[ANT+] Possible causes:")
+                app_logger.error("  - ANT+ USB stick is already in use by another program")
+                app_logger.error("  - USB permission issues (check udev rules)")  
+                app_logger.error("  - USB power management turning off the device")
+                app_logger.error("  - Hardware issue with ANT+ stick")
+                app_logger.debug(traceback.format_exc())
 
     def update(self):
         if self.config.G_ANT["STATUS"] or not self.config.G_DUMMY_OUTPUT:

--- a/modules/sensor_core.py
+++ b/modules/sensor_core.py
@@ -142,7 +142,10 @@ class SensorCore:
         self.process = psutil.Process()
 
         if SensorGPS:
+            import time
+            start = time.time()
             self.sensor_gps = SensorGPS(config, self.values["GPS"])
+            app_logger.debug(f"[GPS] SensorGPS init took: {time.time() - start:.2f}s")
 
         timers = [
             Timer(auto_start=False, text="  ANT+ : {0:.3f} sec"),
@@ -151,7 +154,21 @@ class SensorCore:
         ]
 
         with timers[0]:
-            self.sensor_ant = SensorANT(config, self.values["ANT+"])
+            if not config.G_ANT["STATUS"]:
+                self.sensor_ant = None
+            else:
+                try:
+                    self.sensor_ant = SensorANT(config, self.values["ANT+"])
+                except Exception as e:
+                    import traceback
+                    app_logger.error(f"[ANT+] Failed to initialize ANT+ sensor: {e}")
+                    app_logger.error("[ANT+] Possible causes:")
+                    app_logger.error("  - ANT+ USB stick is already in use by another program")
+                    app_logger.error("  - USB permission issues (check udev rules)")
+                    app_logger.error("  - USB power management turning off the device")
+                    app_logger.error("  - Hardware issue with ANT+ stick")
+                    app_logger.debug(traceback.format_exc())
+                    self.sensor_ant = None
 
         with timers[1]:
             self.sensor_ble = SensorBLE(config, self.values["BLE"])
@@ -282,7 +299,8 @@ class SensorCore:
 
     def start_coroutine(self):
         asyncio.create_task(self.integrate())
-        self.sensor_ant.start_coroutine()
+        if self.sensor_ant:
+            self.sensor_ant.start_coroutine()
         self.sensor_ble.start_coroutine()
         self.sensor_gps.start_coroutine()
         self.sensor_i2c.start_coroutine()
@@ -290,7 +308,8 @@ class SensorCore:
     async def quit(self):
         self.status_quit = True
         self.sensor_i2c.quit()
-        self.sensor_ant.quit()
+        if self.sensor_ant:
+            self.sensor_ant.quit()
         self.sensor_ble.quit()
         await self.sensor_gps.quit()
         self.sensor_gpio.quit()
@@ -298,7 +317,8 @@ class SensorCore:
     # reset accumulated values
     def reset(self):
         self.sensor_gps.reset()
-        self.sensor_ant.reset()
+        if self.sensor_ant:
+            self.sensor_ant.reset()
         self.sensor_i2c.reset()
         self.reset_internal()
 
@@ -398,7 +418,14 @@ class SensorCore:
             # self.sensor_gps.update()
             ant_update_start = time.perf_counter()
             preprocess_elapsed_ms = (ant_update_start - loop_start_perf) * 1000.0
-            self.sensor_ant.update()  # for dummy
+            if self.sensor_ant:
+                try:
+                    self.sensor_ant.update()  # for dummy
+                except Exception as e:
+                    import traceback
+                    app_logger.warning(f"[ANT+] USB communication error in update: {e}")
+                    app_logger.debug(traceback.format_exc())
+
             ant_update_elapsed_ms = (time.perf_counter() - ant_update_start) * 1000.0
             calc_start_perf = time.perf_counter()
 
@@ -803,10 +830,16 @@ class SensorCore:
                         f"pitch={int(pitch_brake_hint)}"
                     )
 
-                if auto_light:
-                    self.sensor_ant.set_light_mode("FLASH_LOW", auto=True)
-                else:
-                    self.sensor_ant.set_light_mode("OFF", auto=True)
+                if self.sensor_ant:
+                    try:
+                        if auto_light:
+                            self.sensor_ant.set_light_mode("FLASH_LOW", auto=True)
+                        else:
+                            self.sensor_ant.set_light_mode("OFF", auto=True)
+                    except Exception as e:
+                        import traceback
+                        app_logger.warning(f"[ANT+] USB communication error in auto light: {e}")
+                        app_logger.debug(traceback.format_exc())
 
             # cpu and memory
             self.values["integrated"]["system_cpu_percent"] = int(

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOCAL_REPO="${LOCAL_REPO:-$SCRIPT_DIR/..}"
+PI_HOST="${PI_HOST:-}"
+PI_PATH="~/pizero_bikecomputer"
+LOG_FILE="log/debug.log"
+VENV_PYTHON="~/.venv/bin/python"
+
+if [[ -z "$PI_HOST" ]]; then
+    echo "Error: PI_HOST not set. Set PI_HOST environment variable or use:"
+    echo "  export PI_HOST=user@raspberry-pi-ip"
+    echo ""
+    echo "Example:"
+    echo "  PI_HOST=pi@192.168.1.100 $0 upload"
+    exit 1
+fi
+
+usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS] COMMAND
+
+Environment Variables:
+    PI_HOST          SSH connection string (e.g., pi@192.168.1.100)
+    LOCAL_REPO       Local repository path (default: auto-detected)
+    VENV_PYTHON      Path to Python venv (default: ~/.venv/bin/python)
+
+Example:
+    export PI_HOST=pi@192.168.1.100
+    $0 upload
+
+Commands:
+    upload      Upload local repo to Pi (rsync)
+    install     Run install.sh on Pi (interactive)
+    start       Start the bikecomputer
+    stop        Stop the bikecomputer
+    logs        Check debug.log for errors
+    watch       Tail the debug.log in real-time
+    deploy      Full workflow: upload + install + start + check logs
+
+Options:
+    -h, --help      Show this help
+    --no-install    Skip install step
+EOF
+
+    exit 1
+}
+
+upload_repo() {
+    echo "📤 Uploading repository to Pi..."
+    rsync -avz --delete \
+        --exclude='.git' \
+        --exclude='__pycache__' \
+        --exclude='*.pyc' \
+        --exclude='.venv' \
+        --exclude='logs/*.log' \
+        "$LOCAL_REPO/" "$PI_HOST:$PI_PATH/"
+    echo "✅ Upload complete"
+}
+
+run_install() {
+    echo "🔧 Running install.sh on Pi..."
+    ssh "$PI_HOST" "cd $PI_PATH && bash install.sh"
+}
+
+start_bikecomputer() {
+    echo "▶️  Starting pizero_bikecomputer..."
+    ssh "$PI_HOST" "cd $PI_PATH && QT_QPA_PLATFORM=offscreen $VENV_PYTHON pizero_bikecomputer.py"
+}
+
+stop_bikecomputer() {
+    echo "⏹️  Stopping pizero_bikecomputer..."
+    ssh "$PI_HOST" "pkill -f pizero_bikecomputer.py || true"
+}
+
+check_logs() {
+    echo "📜 Checking for errors in debug.log..."
+    ssh "$PI_HOST" "grep -i -E '(error|exception|traceback|fail|critical)' $PI_PATH/$LOG_FILE | tail -20" || echo "No errors found"
+}
+
+watch_logs() {
+    echo "📜 Tailing $LOG_FILE (Ctrl+C to exit)..."
+    ssh "$PI_HOST" "tail -f $PI_PATH/$LOG_FILE"
+}
+
+deploy() {
+    local skip_install="${NO_INSTALL:-false}"
+    
+    upload_repo
+    
+    if [[ "$skip_install" != "true" ]]; then
+        run_install
+    fi
+    
+    start_bikecomputer
+    check_logs
+}
+
+NO_INSTALL="false"
+
+COMMAND="${1:-}"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -h|--help) usage ;;
+        --no-install) NO_INSTALL="true" ;;
+    esac
+    shift
+done
+
+case "$COMMAND" in
+    upload) upload_repo ;;
+    install) run_install ;;
+    start) start_bikecomputer ;;
+    stop) stop_bikecomputer ;;
+    logs) check_logs ;;
+    watch) watch_logs ;;
+    deploy) deploy ;;
+    *) usage ;;
+esac

--- a/setting.conf.example
+++ b/setting.conf.example
@@ -1,0 +1,2 @@
+[ANT]
+STATUS = false


### PR DESCRIPTION
Some QOL fixes for a few things regarding the ANT services, and also adding in a deployment script just to assist with pushing to a local PI. 

- Add scripts/deploy.sh for uploading and running on Raspberry Pi
- Make deploy.sh user-agnostic with environment variables
- Add ANT+ sensor error handling with detailed logging messages
- Skip ANT initialization when disabled in setting.conf
- Add wake-up function for ANT USB stick to help with initialization
- Better error handling in ant_device*.py files
- Add setting.conf.example for testing with ANT disabled