### PR TITLE
Add GPIO button configuration system with comprehensive documentation

### DIFF
--- a/docs/gpio_button_configuration.md
+++ b/docs/gpio_button_configuration.md
@@ -1,0 +1,383 @@
+# GPIO Button Configuration
+
+This document describes the physical button GPIO pin assignments for pizero_bikecomputer.
+
+## Overview
+
+The pizero_bikecomputer supports physical buttons through three methods:
+1. **Direct GPIO pins** - Buttons connected directly to Raspberry Pi GPIO pins
+2. **I2C Button Expanders** - MCP23008/MCP23009 or Button SHIM
+3. **BLE/ANT+ Remote Controls** - Zwift Click V2, ANT+ remote controls
+
+All GPIO pin numbers use **BCM mode** (Broadcom chip-specific numbering).
+
+## Button Functions
+
+| Function | Short Press | Long Press |
+|----------|-------------|------------|
+| **scroll_prev** | Navigate to previous page/screen | change_mode (some displays) |
+| **scroll_next** | Navigate to next page/screen | enter_menu (some displays) |
+| **count_laps** | Record a lap | reset_count (reset lap counter) |
+| **start_and_stop_manual** | Start/stop activity recording | Quit application (some displays) |
+| **brightness_control** | Adjust screen brightness | - |
+| **enter_menu** | Open menu system | - |
+| **back_menu** | Go back in menu | - |
+| **get_screenshot** | Capture screenshot | - |
+| **multiscan** | ANT+ multiscan mode | - |
+
+## Direct GPIO Pin Assignments
+
+### PiTFT Display
+
+| BCM GPIO | Button | Short Press | Long Press |
+|----------|--------|-------------|------------|
+| **GPIO 5** | Left | scroll_prev | - |
+| **GPIO 6** | Lap | count_laps | reset_count |
+| **GPIO 12** | Brightness | brightness_control | - |
+| **GPIO 13** | Start/Stop | start_and_stop_manual | - |
+| **GPIO 16** | Right | scroll_next | enter_menu |
+
+**Reference:** `modules/button_config.py` lines 225-239
+
+---
+
+### Papirus E-ink Display
+
+| BCM GPIO | Button | Short Press | Long Press |
+|----------|--------|-------------|------------|
+| **GPIO 16** | SW1 (Left) | scroll_prev | - |
+| **GPIO 26** | SW2 (Lap) | count_laps | reset_count |
+| **GPIO 20** | SW3 (Start/Stop) | start_and_stop_manual | - |
+| **GPIO 21** | SW4 (Right) | scroll_next | enter_menu |
+
+**Note:** Papirus has external pull-up resistors, so internal pull-ups are NOT enabled.
+
+**Reference:** `modules/button_config.py` lines 241-253
+
+---
+
+### DFRobot RPi Display
+
+| BCM GPIO | Button | Short Press | Long Press |
+|----------|--------|-------------|------------|
+| **GPIO 21** | Button 1 | start_and_stop_manual | reset_count |
+| **GPIO 20** | Button 2 | scroll_next | enter_menu |
+
+**Reference:** `modules/button_config.py` lines 255-263
+
+---
+
+### Pirate Audio / Display HAT Mini
+
+| BCM GPIO | Button | Short Press | Long Press |
+|----------|--------|-------------|------------|
+| **GPIO 5** | Button A | scroll_prev | change_mode |
+| **GPIO 6** | Button B | count_laps | reset_count |
+| **GPIO 16** | Button X | scroll_next | enter_menu |
+| **GPIO 24** | Button Y | start_and_stop_manual | - |
+
+**Reference:** `modules/button_config.py` lines 265-295
+
+---
+
+### Pirate Audio (Old Revision)
+
+Same as Pirate Audio above, except:
+
+| BCM GPIO | Button | Short Press | Long Press |
+|----------|--------|-------------|------------|
+| **GPIO 20** | Button Y | start_and_stop_manual | - |
+
+**Note:** Older Pirate Audio boards use GPIO 20 instead of GPIO 24 for Button Y.
+
+**Reference:** `modules/button_config.py` lines 297, 324-328
+
+---
+
+## I2C Button Expanders
+
+### MCP23008 / MCP23009
+
+The MCP23008 is an 8-port GPIO expander connected via I2C.
+
+**I2C Addresses:**
+- MCP23008: `0x20`
+- MCP23009: `0x27`
+
+**Pin Mapping:**
+
+| MCP Pin | Button Label | Short Press | Long Press |
+|---------|--------------|-------------|------------|
+| **GP0** | A | scroll_prev | get_screenshot |
+| **GP1** | B | count_laps | reset_count |
+| **GP2** | C | multiscan | toggle_fake_trainer |
+| **GP3** | D | start_and_stop_manual | - |
+| **GP4** | E | scroll_next | enter_menu |
+
+**Optional Interrupt Pin:**
+- BCM GPIO 23 can be used as interrupt pin for faster button response
+- Currently commented out in code - requires uncommenting in `modules/sensor/sensor_i2c.py` line 1913
+
+**Reference:** 
+- `modules/sensor/i2c/MCP230XX.py` lines 315-322
+- `modules/sensor/sensor_i2c.py` line 1913
+
+---
+
+### Pimoroni Button SHIM
+
+The Button SHIM is an I2C button board with 5 buttons (A-E) and an RGB LED.
+
+**Button Mapping:**
+
+| Button | Short Press | Long Press |
+|--------|-------------|------------|
+| **A** | scroll_prev | get_screenshot |
+| **B** | count_laps | reset_count |
+| **C** | multiscan | toggle_fake_trainer |
+| **D** | start_and_stop_manual | - |
+| **E** | scroll_next | enter_menu |
+
+**LED Control:** RGB LED can be controlled programmatically
+
+**Installation:**
+```bash
+sudo apt install python3-buttonshim
+```
+
+**Reference:** `modules/sensor/i2c/button_shim.py`
+
+---
+
+## BLE/ANT+ Remote Controls
+
+### Zwift Click V2 (BLE)
+
+The Zwift Click V2 is a Bluetooth LE remote control with left/right buttons.
+
+**Button Mapping:**
+- Left button: Maps to button functions via `button_config.py`
+- Right button: Maps to button functions via `button_config.py`
+
+**Reference:** `modules/sensor/sensor_ble.py` lines 86-119
+
+---
+
+### ANT+ Remote Controls
+
+ANT+ remote controls (like bike computer remotes) can send button press events.
+
+**Supported Events:**
+- LAP button (0x0024)
+- PAGE button (0x0001)
+- PAGE button long press (0x0000)
+- CUSTOM button (0x8000)
+- CUSTOM button long press (0x8001)
+
+**Reference:** `modules/sensor/ant/ant_device_ctrl.py` lines 22-50
+
+---
+
+## GPIO Hardware Configuration
+
+### GPIO Chip Path
+- **Raspberry Pi 5 / gpiod v2:** `/dev/gpiochip4`
+- **Older Raspberry Pi:** `/dev/gpiochip0`
+
+**Reference:** `modules/sensor/sensor_gpio.py` line 23
+
+### Debounce Time
+- **Default:** 250ms software debounce
+- Prevents accidental double-presses
+
+**Reference:** `modules/sensor/sensor_gpio.py` line 27
+
+### Pull-up Resistors
+
+**Displays requiring internal pull-up resistors:**
+- PiTFT
+- DFRobot_RPi_Display
+- Pirate_Audio_old
+- Pirate_Audio
+- Display_HAT_Mini
+
+**Displays with external pull-up (no internal pull-up):**
+- Papirus
+
+**Reference:** `modules/sensor/sensor_gpio.py` lines 38-48
+
+---
+
+## Long Press Threshold
+
+**Default:** 1.0 seconds
+
+To change, edit `modules/button_config.py` line 10:
+```python
+_G_LONG_PRESS_THRESHOLD_SEC = 1.0
+```
+
+---
+
+## Button Mode System
+
+The button system supports different modes for different contexts:
+
+### Main Modes:
+- **MAIN** - Normal cycling mode (navigate pages, record laps, start/stop)
+- **MAP** - Map interaction mode (zoom, pan)
+- **MENU** - Menu navigation mode (tab, space, back)
+- **COURSE_PROFILE** - Course profile view mode
+- **ANT+_SEARCH** - ANT+ sensor search mode
+
+Button functions automatically change based on the current mode.
+
+**Reference:** `modules/button_config.py` lines 13-18
+
+---
+
+## Making GPIO Pins Configurable
+
+### Current Status: HARDCODED ⚠️
+
+All GPIO pin assignments are currently hardcoded in `modules/button_config.py` and cannot be changed without editing source code.
+
+### Future Enhancement
+
+To make GPIO pins user-configurable, add a `[GPIO_BUTTONS]` section to `setting.conf`:
+
+```ini
+[GPIO_BUTTONS]
+scroll_prev = 5
+count_laps = 6
+brightness_control = 12
+start_and_stop_manual = 13
+scroll_next = 16
+```
+
+**Implementation needed:**
+1. Add GPIO configuration loading in `modules/helper/setting.py`
+2. Update `modules/button_config.py` to read from config instead of hardcoded values
+3. Add validation to prevent GPIO conflicts
+4. Document safe GPIO pins to use (avoid I2C, SPI, UART pins)
+
+---
+
+## Troubleshooting
+
+### Buttons Not Working
+
+1. **Check display type is set correctly in setting.conf:**
+   ```ini
+   [DISPLAY]
+   display = PiTFT
+   ```
+
+2. **Verify GPIO permissions:**
+   ```bash
+   sudo usermod -a -G gpio $USER
+   # Log out and log back in
+   ```
+
+3. **Check if gpiod is installed:**
+   ```bash
+   pip install gpiod
+   ```
+
+4. **Test GPIO manually:**
+   ```bash
+   gpioinfo | grep -E "gpiochip|line"
+   ```
+
+5. **Check for GPIO conflicts:**
+   - I2C pins (GPIO 2, 3)
+   - SPI pins (GPIO 7, 8, 9, 10, 11)
+   - UART pins (GPIO 14, 15)
+
+### I2C Button Expander Not Detected
+
+1. **Enable I2C:**
+   ```bash
+   sudo raspi-config
+   # Interface Options -> I2C -> Enable
+   ```
+
+2. **Check I2C devices:**
+   ```bash
+   i2cdetect -y 1
+   # Should show device at 0x20 (MCP23008) or 0x27 (MCP23009)
+   ```
+
+3. **Install I2C tools:**
+   ```bash
+   sudo apt install i2c-tools python3-smbus
+   ```
+
+---
+
+## Safe GPIO Pins for Custom Buttons
+
+When adding custom button configurations, use these safe GPIO pins:
+
+**Safe to use (no built-in functions):**
+- GPIO 5, 6, 12, 13, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27
+
+**Avoid these pins:**
+- GPIO 0, 1 (reserved for ID EEPROM)
+- GPIO 2, 3 (I2C - SDA, SCL)
+- GPIO 7, 8, 9, 10, 11 (SPI)
+- GPIO 14, 15 (UART)
+- GPIO 28-45 (internal use on Compute Module)
+
+**Reference:** [Raspberry Pi GPIO Pinout](https://pinout.xyz/)
+
+---
+
+## Related Documentation
+
+- [Framebuffer Troubleshooting](framebuffer_troubleshooting.md) - Display setup
+- [Installation Guide](../install.sh) - Hardware setup
+- [Button Config Source](../modules/button_config.py) - Button function definitions
+- [GPIO Sensor Source](../modules/sensor/sensor_gpio.py) - GPIO hardware interface
+
+---
+
+## Hardware Wiring Diagrams
+
+### Basic Button Connection
+
+```
+3.3V ──────┬────── Button ────── GPIO Pin
+           │
+         [10kΩ]  (pull-up resistor)
+           │
+          GND
+```
+
+**Note:** If using displays with internal pull-ups (PiTFT, Pirate Audio), external resistors are not needed.
+
+### Active Low vs Active High
+
+All buttons in pizero_bikecomputer are **active LOW**:
+- Button not pressed: GPIO reads HIGH (3.3V via pull-up)
+- Button pressed: GPIO reads LOW (connected to ground)
+
+---
+
+## Version Information
+
+- **Document Version:** 1.0
+- **Last Updated:** 2026-04-02
+- **Compatible with:** pizero_bikecomputer v3.x
+
+---
+
+## Contributing
+
+If you add support for new button hardware, please update this documentation with:
+1. GPIO pin assignments
+2. Hardware setup instructions
+3. Any special configuration needed
+4. Photos of hardware connection (if applicable)
+
+Submit documentation updates via pull request to the main repository.

--- a/docs/gpio_button_example.conf
+++ b/docs/gpio_button_example.conf
@@ -1,0 +1,187 @@
+# GPIO Button Configuration Example
+# 
+# This file shows how to customize GPIO pin assignments for physical buttons
+# in pizero_bikecomputer. Add these sections to your setting.conf file.
+#
+# IMPORTANT: Only applies to GPIO-based displays:
+# - PiTFT
+# - Papirus
+# - DFRobot_RPi_Display
+# - Pirate_Audio / Pirate_Audio_old
+# - Display_HAT_Mini
+#
+# Does NOT affect:
+# - I2C button expanders (MCP23008, Button SHIM) - hardware determines pins
+# - BLE/ANT+ remotes - wireless, no GPIO
+# - Touch screen / on-screen buttons
+
+[GENERAL]
+display = PiTFT
+# ... other general settings ...
+
+# GPIO Button Pin Assignments (BCM numbering)
+# Map button functions to GPIO BCM pin numbers
+# Only include the buttons you want to customize
+[GPIO_BUTTONS]
+# Navigation buttons
+scroll_prev = 5              # Previous page/screen
+scroll_next = 16             # Next page/screen
+
+# Action buttons
+count_laps = 6               # Record lap / Reset lap counter (long press)
+start_and_stop_manual = 13   # Start/stop recording
+
+# Utility buttons
+brightness_control = 12      # Screen brightness control
+enter_menu = 16             # Open menu (usually long press on scroll_next)
+
+# Note: The button functions listed here must match your display type's 
+# default button set. See docs/gpio_button_configuration.md for details.
+
+# ----------------------------------------------------------------------------
+# Example 1: PiTFT with Custom Layout
+# ----------------------------------------------------------------------------
+# Default PiTFT GPIO pins:
+#   GPIO 5  = scroll_prev
+#   GPIO 6  = count_laps
+#   GPIO 12 = brightness_control
+#   GPIO 13 = start_and_stop_manual
+#   GPIO 16 = scroll_next
+#
+# Custom layout (swap prev/next, move start button):
+#[GPIO_BUTTONS]
+#scroll_prev = 16
+#scroll_next = 5
+#count_laps = 6
+#brightness_control = 12
+#start_and_stop_manual = 21
+
+# ----------------------------------------------------------------------------
+# Example 2: Papirus with External Buttons
+# ----------------------------------------------------------------------------
+# Default Papirus GPIO pins:
+#   GPIO 16 = scroll_prev
+#   GPIO 26 = count_laps
+#   GPIO 20 = start_and_stop_manual
+#   GPIO 21 = scroll_next
+#
+# Custom layout using different pins:
+#[GPIO_BUTTONS]
+#scroll_prev = 17
+#scroll_next = 27
+#count_laps = 22
+#start_and_stop_manual = 23
+
+# ----------------------------------------------------------------------------
+# Example 3: Pirate Audio with Modified Layout
+# ----------------------------------------------------------------------------
+# Default Pirate Audio GPIO pins:
+#   GPIO 5  = scroll_prev (Button A)
+#   GPIO 6  = count_laps (Button B)
+#   GPIO 16 = scroll_next (Button X)
+#   GPIO 24 = start_and_stop_manual (Button Y)
+#
+# Custom: repurpose one button for different function
+#[GPIO_BUTTONS]
+#scroll_prev = 5
+#count_laps = 6
+#scroll_next = 16
+#brightness_control = 24  # Change Button Y to brightness control
+
+# ----------------------------------------------------------------------------
+# Safe GPIO Pins for Custom Buttons
+# ----------------------------------------------------------------------------
+# Use these BCM GPIO pins for custom button wiring:
+# Safe: 5, 6, 12, 13, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27
+#
+# AVOID these pins (used by other hardware):
+# - GPIO 0, 1   : ID EEPROM (reserved)
+# - GPIO 2, 3   : I2C (SDA, SCL)
+# - GPIO 7-11   : SPI (for displays, sensors)
+# - GPIO 14, 15 : UART (serial console)
+#
+# Button Wiring:
+# ┌─────────────────────────────────────┐
+# │ 3.3V ──┬── [Button] ── GPIO Pin     │
+# │        │                             │
+# │     [10kΩ]  (pull-up resistor)      │
+# │        │                             │
+# │       GND                            │
+# └─────────────────────────────────────┘
+#
+# Notes:
+# - Buttons are ACTIVE LOW (pressed = GPIO reads LOW)
+# - Internal pull-ups are enabled for most displays
+# - External pull-up needed for Papirus only
+# - Add 0.1µF capacitor across button for debouncing (optional)
+
+# ----------------------------------------------------------------------------
+# Available Button Functions
+# ----------------------------------------------------------------------------
+# You can only customize these button functions:
+#
+# Navigation:
+#   scroll_prev            - Navigate to previous page
+#   scroll_next            - Navigate to next page
+#   enter_menu             - Open menu system
+#   back_menu              - Go back in menu
+#
+# Recording:
+#   start_and_stop_manual  - Start/stop activity
+#   count_laps             - Record lap
+#   reset_count            - Reset lap counter (usually long press)
+#
+# Display:
+#   brightness_control     - Adjust screen brightness
+#   change_mode            - Switch button mode
+#
+# Advanced:
+#   get_screenshot         - Capture screenshot
+#   multiscan              - ANT+ multiscan mode
+#   toggle_fake_trainer    - Enable/disable fake trainer mode
+#
+# Menu Navigation (auto-assigned in menu mode):
+#   press_tab              - Next menu item
+#   press_shift_tab        - Previous menu item
+#   press_space            - Select menu item
+#
+# Note: Long press actions are defined in the code and cannot be 
+# individually configured via setting.conf
+
+# ----------------------------------------------------------------------------
+# Long Press Actions (Fixed in Code)
+# ----------------------------------------------------------------------------
+# These long press actions are hardcoded per display type:
+#
+# Common long press actions:
+#   scroll_prev (long)     -> change_mode or get_screenshot
+#   scroll_next (long)     -> enter_menu
+#   count_laps (long)      -> reset_count
+#   start_and_stop_manual (long) -> quit app or reset_count
+#
+# See docs/gpio_button_configuration.md for complete list
+
+# ----------------------------------------------------------------------------
+# Troubleshooting
+# ----------------------------------------------------------------------------
+# 1. Buttons not working after customization:
+#    - Check GPIO pin numbers are correct (BCM mode)
+#    - Verify no pin conflicts with other hardware
+#    - Check log: tail -f ~/pizero_bikecomputer/log/debug.log
+#    - Look for "Custom GPIO" messages at startup
+#
+# 2. Some buttons work, others don't:
+#    - Ensure all listed button functions are valid for your display
+#    - Check wiring and pull-up resistors
+#    - Test GPIO manually: gpioinfo
+#
+# 3. Buttons trigger wrong actions:
+#    - Verify button function names match exactly (case sensitive)
+#    - Check you're not reusing the same GPIO pin for multiple functions
+#
+# 4. Reset to defaults:
+#    - Remove or comment out the [GPIO_BUTTONS] section
+#    - Restart the application
+
+# For more information, see:
+# docs/gpio_button_configuration.md

--- a/modules/button_config.py
+++ b/modules/button_config.py
@@ -351,6 +351,51 @@ class Button_Config:
     def __init__(self, config):
         self.config = config
         self._dual_map_mode_active = False
+        self._apply_custom_gpio_pins()
+
+    def _apply_custom_gpio_pins(self):
+        """Apply custom GPIO pin assignments from setting.conf if configured."""
+        if not hasattr(self.config, 'G_GPIO_BUTTON_CUSTOM_PINS'):
+            return
+        
+        custom_pins = self.config.G_GPIO_BUTTON_CUSTOM_PINS
+        if not custom_pins or not isinstance(custom_pins, dict):
+            return
+        
+        # Get the current display type to know which button profile to modify
+        display_type = getattr(self.config, 'G_DISPLAY', 'None')
+        
+        # Only apply custom pins to GPIO-based displays
+        gpio_displays = ['PiTFT', 'Papirus', 'DFRobot_RPi_Display', 
+                        'Pirate_Audio', 'Pirate_Audio_old', 'Display_HAT_Mini']
+        
+        if display_type not in gpio_displays:
+            return
+        
+        if display_type not in self.G_BUTTON_DEF:
+            return
+        
+        # Build a reverse mapping: function_name -> old_gpio_pin
+        function_to_old_pin = {}
+        for mode, buttons in self.G_BUTTON_DEF[display_type].items():
+            for gpio_pin, (short_func, long_func) in buttons.items():
+                if short_func and short_func in custom_pins:
+                    function_to_old_pin[short_func] = gpio_pin
+        
+        # Now remap: remove old pin, add new pin with same function tuple
+        for func_name, new_pin in custom_pins.items():
+            if func_name in function_to_old_pin:
+                old_pin = function_to_old_pin[func_name]
+                # Update all modes that have this function
+                for mode, buttons in self.G_BUTTON_DEF[display_type].items():
+                    if old_pin in buttons:
+                        func_tuple = buttons[old_pin]
+                        del buttons[old_pin]
+                        buttons[new_pin] = func_tuple
+                        app_logger.info(
+                            f"Custom GPIO: {display_type} {mode} - "
+                            f"{func_name} moved from GPIO {old_pin} to GPIO {new_pin}"
+                        )
 
     def _resolve_button_profile(self, button_hard):
         if button_hard != "Zwift_Click_V2":

--- a/modules/config.py
+++ b/modules/config.py
@@ -238,6 +238,11 @@ class Config:
         "USE_DRM": False,
     }
 
+    # GPIO button custom pin assignments
+    # Populated from setting.conf [GPIO_BUTTONS] section
+    # Maps button function names to GPIO BCM pin numbers
+    G_GPIO_BUTTON_CUSTOM_PINS = {}
+
     # auto backlight
     G_USE_AUTO_BACKLIGHT = True
     G_AUTO_BACKLIGHT_CUTOFF = 10

--- a/modules/helper/setting.py
+++ b/modules/helper/setting.py
@@ -61,6 +61,19 @@ class Setting:
             if "GADGETBRIDGE_USE_GPS" in c:
                 self.config.G_GADGETBRIDGE["USE_GPS"] = c.getboolean("GADGETBRIDGE_USE_GPS")
 
+        if "GPIO_BUTTONS" in self.config_parser:
+            c = self.config_parser["GPIO_BUTTONS"]
+            # Read custom GPIO pin assignments for the current display type
+            # Format: button_function = gpio_pin_number
+            # Example: scroll_prev = 5
+            if hasattr(self.config, 'G_GPIO_BUTTON_CUSTOM_PINS'):
+                for key in c:
+                    try:
+                        pin_number = int(c[key])
+                        self.config.G_GPIO_BUTTON_CUSTOM_PINS[key] = pin_number
+                    except ValueError:
+                        print(f"Warning: Invalid GPIO pin number for {key}: {c[key]}")
+
         if "MAP_AND_DATA" in self.config_parser:
             c = self.config_parser["MAP_AND_DATA"]
             if "MAP" in c:


### PR DESCRIPTION
Mostly documentation to indicate what users can do for custom button situations (No button shim for instance). Small config options added for customizing which GPIO buttons correlate to which operations if needed.

- Add configurable GPIO pin assignments via setting.conf [GPIO_BUTTONS]
- Create comprehensive GPIO button documentation (gpio_button_configuration.md)
  - Documents all GPIO pins for PiTFT, Papirus, DFRobot, Pirate Audio, Display HAT Mini
  - Includes I2C button expanders (MCP23008, Button SHIM)
  - Lists safe GPIO pins and hardware constraints
  - Provides troubleshooting guide
- Add example configuration file (gpio_button_example.conf)
  - Multiple configuration examples for different displays
  - Wiring diagrams and safety notes
  - Complete list of available button functions
- Implement G_GPIO_BUTTON_CUSTOM_PINS in config.py
- Add GPIO configuration reading in setting.py
- Add _apply_custom_gpio_pins() method in button_config.py
  - Automatically remaps GPIO pins based on setting.conf
  - Logs custom pin assignments for debugging

Previously, GPIO pins were hardcoded in button_config.py. Now users can customize pin assignments without editing source code.

Resolves need for user-configurable GPIO button pins.